### PR TITLE
feat(relayer): requeue pending orders on failure

### DIFF
--- a/relayer/src/__tests__/relayerService.test.js
+++ b/relayer/src/__tests__/relayerService.test.js
@@ -1,0 +1,110 @@
+const fs = require('fs');
+const path = require('path');
+const ts = require('typescript');
+const { Keypair } = require('@solana/web3.js');
+
+function loadRelayerService() {
+  const Module = require('module');
+  const baseDir = path.resolve(__dirname, '..');
+
+  // Compile relayerService.ts and stub config dependency
+  const serviceTsPath = path.join(baseDir, 'relayerService.ts');
+  const serviceSource = fs.readFileSync(serviceTsPath, 'utf8');
+  let { outputText } = ts.transpileModule(serviceSource, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2019 },
+  });
+  outputText = outputText.replace(
+    'require("./config")',
+    '{ config: { supportedPools: [], priorityFeeLevel: "none" } }'
+  );
+  const serviceJsPath = path.join(baseDir, 'relayerService.js');
+  const serviceModule = new Module(serviceJsPath, module);
+  serviceModule.paths = Module._nodeModulePaths(baseDir);
+  serviceModule._compile(outputText, serviceJsPath);
+  return serviceModule.exports.RelayerService;
+}
+
+const RelayerService = loadRelayerService();
+
+describe('RelayerService requeue behaviour', () => {
+  const dummyConnection = {};
+  const relayerWallet = Keypair.generate();
+  const programId = Keypair.generate().publicKey;
+  const cpSwapProgramId = Keypair.generate().publicKey;
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+  test('requeuePendingOrders is called and queue restored', async () => {
+    const service = new RelayerService(
+      dummyConnection,
+      relayerWallet,
+      programId,
+      cpSwapProgramId,
+      logger
+    );
+
+    const poolId = Keypair.generate().publicKey;
+    const user = Keypair.generate().publicKey;
+
+    const order1 = await service.submitOrder({
+      poolId,
+      amountIn: '100',
+      minAmountOut: '90',
+      isBaseInput: true,
+      userPublicKey: user,
+    });
+    const order2 = await service.submitOrder({
+      poolId,
+      amountIn: '100',
+      minAmountOut: '90',
+      isBaseInput: true,
+      userPublicKey: user,
+    });
+
+    const spy = jest.spyOn(service, 'requeuePendingOrders');
+
+    await service.executeOrder(order1.orderId);
+
+    expect(spy).toHaveBeenCalledWith(order1.orderId);
+    expect(service.executionQueue).toEqual([order1.orderId, order2.orderId]);
+  });
+
+  test('later orders are retried after failure', async () => {
+    const service = new RelayerService(
+      dummyConnection,
+      relayerWallet,
+      programId,
+      cpSwapProgramId,
+      logger
+    );
+
+    const poolId = Keypair.generate().publicKey;
+    const user = Keypair.generate().publicKey;
+
+    const order1 = await service.submitOrder({
+      poolId,
+      amountIn: '100',
+      minAmountOut: '90',
+      isBaseInput: true,
+      userPublicKey: user,
+    });
+    const order2 = await service.submitOrder({
+      poolId,
+      amountIn: '100',
+      minAmountOut: '90',
+      isBaseInput: true,
+      userPublicKey: user,
+    });
+
+    await service.executeOrder(order1.orderId);
+
+    let next = service.executionQueue.shift();
+    await service.executeOrder(next);
+
+    next = service.executionQueue.shift();
+    expect(next).toBe(order2.orderId);
+    expect(service.orders.get(order2.orderId).status).toBe('pending');
+
+    await service.executeOrder(next);
+    expect(service.orders.get(order2.orderId).status).toBe('failed');
+  });
+});

--- a/relayer/src/relayerService.ts
+++ b/relayer/src/relayerService.ts
@@ -464,6 +464,26 @@ export class RelayerService extends EventEmitter {
     }
   }
 
+  private requeuePendingOrders(fromOrderId: string) {
+    const pendingOrders = Array.from(this.orders.values())
+      .filter(
+        (o) => o.status === "pending" || o.orderId === fromOrderId
+      )
+      .sort((a, b) => new BN(a.sequence).cmp(new BN(b.sequence)))
+      .map((o) => o.orderId);
+
+    const uniqueExisting = new Set(pendingOrders);
+    this.executionQueue = [
+      ...pendingOrders,
+      ...this.executionQueue.filter((id) => !uniqueExisting.has(id)),
+    ];
+
+    this.logger.info("Requeued pending orders", {
+      fromOrderId,
+      requeuedOrderIds: pendingOrders,
+    });
+  }
+
   private async executeOrder(orderId: string) {
     const order = this.orders.get(orderId);
     if (!order || order.status !== "pending") return;
@@ -832,6 +852,8 @@ export class RelayerService extends EventEmitter {
       order.status = "failed";
       order.error = error instanceof Error ? error.message : String(error);
       this.stats.failedOrders++;
+
+      this.requeuePendingOrders(orderId);
 
       // Check if this is a "transaction already processed" error
       const errorMessage =


### PR DESCRIPTION
## Summary
- add `requeuePendingOrders` helper to restore pending queue
- requeue orders when execution fails
- add tests around queue reattempt

## Testing
- `cd relayer && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b02b250a1c8331a4b1f0c52f9592f7