### PR TITLE
Add LP deposit and withdraw wrappers for Raydium CP-Swap

### DIFF
--- a/programs/continuum-cp-swap/src/instructions/lp_deposit_withdraw.rs
+++ b/programs/continuum-cp-swap/src/instructions/lp_deposit_withdraw.rs
@@ -1,0 +1,180 @@
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{
+    instruction::{AccountMeta, Instruction},
+    program::invoke_signed,
+};
+use crate::errors::ContinuumError;
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct DepositLiquidity<'info> {
+    #[account(
+        mut,
+        seeds = [b"fifo_state"],
+        bump,
+        constraint = !fifo_state.emergency_pause @ ContinuumError::EmergencyPause,
+    )]
+    pub fifo_state: Account<'info, FifoState>,
+
+    /// CHECK: CP-Swap program
+    pub cp_swap_program: UncheckedAccount<'info>,
+    // Remaining accounts passed through to CP-Swap
+}
+
+pub fn deposit_liquidity<'info>(
+    ctx: Context<'_, '_, '_, 'info, DepositLiquidity<'info>>,
+    min_lp_amount: u64,
+    max_token_0_amount: u64,
+    max_token_1_amount: u64,
+    pool_id: Pubkey,
+    pool_authority_bump: u8,
+) -> Result<()> {
+    let fifo_state = &mut ctx.accounts.fifo_state;
+    let sequence = fifo_state.current_sequence + 1;
+    fifo_state.current_sequence = sequence;
+
+    msg!("Deposit liquidity {} on pool {}", sequence, pool_id);
+
+    // Build CP-Swap deposit instruction data
+    let mut ix_data = Vec::new();
+    // discriminator for cp-swap deposit
+    ix_data.extend_from_slice(&[242, 35, 198, 137, 82, 225, 242, 182]);
+    ix_data.extend_from_slice(&min_lp_amount.to_le_bytes());
+    ix_data.extend_from_slice(&max_token_0_amount.to_le_bytes());
+    ix_data.extend_from_slice(&max_token_1_amount.to_le_bytes());
+
+    // Build account metas from remaining accounts
+    let mut account_metas = vec![];
+    for (i, account) in ctx.remaining_accounts.iter().enumerate() {
+        if i == 0 {
+            account_metas.push(AccountMeta::new_readonly(account.key(), true));
+        } else {
+            account_metas.push(if account.is_writable {
+                AccountMeta::new(account.key(), false)
+            } else {
+                AccountMeta::new_readonly(account.key(), false)
+            });
+        }
+    }
+
+    // Create instruction
+    let ix = Instruction {
+        program_id: ctx.accounts.cp_swap_program.key(),
+        accounts: account_metas,
+        data: ix_data,
+    };
+
+    // Pool authority signer seeds
+    let pool_authority_seeds = &[
+        b"cp_pool_authority",
+        pool_id.as_ref(),
+        &[pool_authority_bump],
+    ];
+
+    // Build CPI account array including cp_swap_program
+    let cpi_accounts: Vec<AccountInfo<'info>> =
+        std::iter::once(ctx.accounts.cp_swap_program.to_account_info())
+            .chain(ctx.remaining_accounts.iter().cloned())
+            .collect();
+
+    invoke_signed(&ix, &cpi_accounts, &[pool_authority_seeds])?;
+
+    emit!(LiquidityDeposited {
+        sequence,
+        pool_id,
+        min_lp_amount,
+    });
+
+    Ok(())
+}
+
+#[event]
+pub struct LiquidityDeposited {
+    pub sequence: u64,
+    pub pool_id: Pubkey,
+    pub min_lp_amount: u64,
+}
+
+#[derive(Accounts)]
+pub struct WithdrawLiquidity<'info> {
+    #[account(
+        mut,
+        seeds = [b"fifo_state"],
+        bump,
+        constraint = !fifo_state.emergency_pause @ ContinuumError::EmergencyPause,
+    )]
+    pub fifo_state: Account<'info, FifoState>,
+
+    /// CHECK: CP-Swap program
+    pub cp_swap_program: UncheckedAccount<'info>,
+    // Remaining accounts passed through to CP-Swap
+}
+
+pub fn withdraw_liquidity<'info>(
+    ctx: Context<'_, '_, '_, 'info, WithdrawLiquidity<'info>>,
+    lp_amount: u64,
+    min_token_0_amount: u64,
+    min_token_1_amount: u64,
+    pool_id: Pubkey,
+    pool_authority_bump: u8,
+) -> Result<()> {
+    let fifo_state = &mut ctx.accounts.fifo_state;
+    let sequence = fifo_state.current_sequence + 1;
+    fifo_state.current_sequence = sequence;
+
+    msg!("Withdraw liquidity {} on pool {}", sequence, pool_id);
+
+    let mut ix_data = Vec::new();
+    // discriminator for cp-swap withdraw
+    ix_data.extend_from_slice(&[183, 18, 70, 156, 148, 109, 161, 34]);
+    ix_data.extend_from_slice(&lp_amount.to_le_bytes());
+    ix_data.extend_from_slice(&min_token_0_amount.to_le_bytes());
+    ix_data.extend_from_slice(&min_token_1_amount.to_le_bytes());
+
+    let mut account_metas = vec![];
+    for (i, account) in ctx.remaining_accounts.iter().enumerate() {
+        if i == 0 {
+            account_metas.push(AccountMeta::new_readonly(account.key(), true));
+        } else {
+            account_metas.push(if account.is_writable {
+                AccountMeta::new(account.key(), false)
+            } else {
+                AccountMeta::new_readonly(account.key(), false)
+            });
+        }
+    }
+
+    let ix = Instruction {
+        program_id: ctx.accounts.cp_swap_program.key(),
+        accounts: account_metas,
+        data: ix_data,
+    };
+
+    let pool_authority_seeds = &[
+        b"cp_pool_authority",
+        pool_id.as_ref(),
+        &[pool_authority_bump],
+    ];
+
+    let cpi_accounts: Vec<AccountInfo<'info>> =
+        std::iter::once(ctx.accounts.cp_swap_program.to_account_info())
+            .chain(ctx.remaining_accounts.iter().cloned())
+            .collect();
+
+    invoke_signed(&ix, &cpi_accounts, &[pool_authority_seeds])?;
+
+    emit!(LiquidityWithdrawn {
+        sequence,
+        pool_id,
+        lp_amount,
+    });
+
+    Ok(())
+}
+
+#[event]
+pub struct LiquidityWithdrawn {
+    pub sequence: u64,
+    pub pool_id: Pubkey,
+    pub lp_amount: u64,
+}

--- a/programs/continuum-cp-swap/src/instructions/mod.rs
+++ b/programs/continuum-cp-swap/src/instructions/mod.rs
@@ -5,6 +5,7 @@ pub mod submit_order_simple;
 pub mod execute_order;
 pub mod cancel_order;
 pub mod swap_immediate;
+pub mod lp_deposit_withdraw;
 
 pub use initialize::*;
 pub use initialize_cp_swap_pool::*;
@@ -13,3 +14,4 @@ pub use submit_order_simple::*;
 pub use execute_order::*;
 pub use cancel_order::*;
 pub use swap_immediate::*;
+pub use lp_deposit_withdraw::*;

--- a/programs/continuum-cp-swap/src/instructions/swap_immediate.rs
+++ b/programs/continuum-cp-swap/src/instructions/swap_immediate.rs
@@ -23,8 +23,8 @@ pub struct SwapImmediate<'info> {
     // are passed through in remaining_accounts to avoid deserialization
 }
 
-pub fn swap_immediate(
-    ctx: Context<SwapImmediate>,
+pub fn swap_immediate<'info>(
+    ctx: Context<'_, '_, '_, 'info, SwapImmediate<'info>>,
     amount_in: u64,
     min_amount_out: u64,
     is_base_input: bool,
@@ -83,8 +83,10 @@ pub fn swap_immediate(
     ];
     
     // Build accounts array for CPI, including the cp_swap_program
-    let mut cpi_accounts = vec![ctx.accounts.cp_swap_program.to_account_info()];
-    cpi_accounts.extend(ctx.remaining_accounts.iter().cloned());
+    let cpi_accounts: Vec<AccountInfo<'info>> =
+        std::iter::once(ctx.accounts.cp_swap_program.to_account_info())
+            .chain(ctx.remaining_accounts.iter().cloned())
+            .collect();
     
     // Pass all accounts to invoke_signed
     invoke_signed(

--- a/programs/continuum-cp-swap/src/lib.rs
+++ b/programs/continuum-cp-swap/src/lib.rs
@@ -63,8 +63,8 @@ pub mod continuum_cp_swap {
     }
 
     /// Immediate swap - submit and execute in one transaction
-    pub fn swap_immediate(
-        ctx: Context<SwapImmediate>,
+    pub fn swap_immediate<'info>(
+        ctx: Context<'_, '_, '_, 'info, SwapImmediate<'info>>,
         amount_in: u64,
         min_amount_out: u64,
         is_base_input: bool,
@@ -72,5 +72,43 @@ pub mod continuum_cp_swap {
         pool_authority_bump: u8,
     ) -> Result<()> {
         instructions::swap_immediate(ctx, amount_in, min_amount_out, is_base_input, pool_id, pool_authority_bump)
+    }
+
+    /// Deposit liquidity into a CP-Swap pool
+    pub fn deposit_liquidity<'info>(
+        ctx: Context<'_, '_, '_, 'info, DepositLiquidity<'info>>,
+        min_lp_amount: u64,
+        max_token_0_amount: u64,
+        max_token_1_amount: u64,
+        pool_id: Pubkey,
+        pool_authority_bump: u8,
+    ) -> Result<()> {
+        instructions::deposit_liquidity(
+            ctx,
+            min_lp_amount,
+            max_token_0_amount,
+            max_token_1_amount,
+            pool_id,
+            pool_authority_bump,
+        )
+    }
+
+    /// Withdraw liquidity from a CP-Swap pool
+    pub fn withdraw_liquidity<'info>(
+        ctx: Context<'_, '_, '_, 'info, WithdrawLiquidity<'info>>,
+        lp_amount: u64,
+        min_token_0_amount: u64,
+        min_token_1_amount: u64,
+        pool_id: Pubkey,
+        pool_authority_bump: u8,
+    ) -> Result<()> {
+        instructions::withdraw_liquidity(
+            ctx,
+            lp_amount,
+            min_token_0_amount,
+            min_token_1_amount,
+            pool_id,
+            pool_authority_bump,
+        )
     }
 }

--- a/sdk/src/instructions/index.ts
+++ b/sdk/src/instructions/index.ts
@@ -4,3 +4,4 @@ export * from './submitOrder';
 export * from './executeOrder';
 export * from './cancelOrder';
 export * from './swapImmediate';
+export * from './lpDepositWithdraw';

--- a/sdk/src/instructions/lpDepositWithdraw.ts
+++ b/sdk/src/instructions/lpDepositWithdraw.ts
@@ -1,0 +1,106 @@
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import BN from 'bn.js';
+import { CONTINUUM_PROGRAM_ID } from '../constants';
+import { getFifoStatePDA } from '../utils';
+
+// Discriminators for wrapper instructions
+const DEPOSIT_LIQUIDITY_DISCRIMINATOR = Buffer.from([245, 99, 59, 25, 151, 71, 233, 249]);
+const WITHDRAW_LIQUIDITY_DISCRIMINATOR = Buffer.from([149, 158, 33, 185, 47, 243, 253, 31]);
+
+export interface DepositLiquidityParams {
+  cpSwapProgram: PublicKey;
+  poolId: PublicKey;
+  minLpAmount: BN;
+  maxToken0Amount: BN;
+  maxToken1Amount: BN;
+  poolAuthorityBump: number;
+  owner: PublicKey;
+  lpMint: PublicKey;
+  userToken0: PublicKey;
+  userToken1: PublicKey;
+  userLp: PublicKey;
+  token0Vault: PublicKey;
+  token1Vault: PublicKey;
+  tokenProgram: PublicKey;
+}
+
+export interface WithdrawLiquidityParams {
+  cpSwapProgram: PublicKey;
+  poolId: PublicKey;
+  lpAmount: BN;
+  minToken0Amount: BN;
+  minToken1Amount: BN;
+  poolAuthorityBump: number;
+  owner: PublicKey;
+  lpMint: PublicKey;
+  userToken0: PublicKey;
+  userToken1: PublicKey;
+  userLp: PublicKey;
+  token0Vault: PublicKey;
+  token1Vault: PublicKey;
+  tokenProgram: PublicKey;
+}
+
+export function createDepositLiquidityInstruction(params: DepositLiquidityParams): TransactionInstruction {
+  const [fifoState] = getFifoStatePDA();
+  const keys = [
+    { pubkey: fifoState, isSigner: false, isWritable: true },
+    { pubkey: params.cpSwapProgram, isSigner: false, isWritable: false },
+    { pubkey: params.owner, isSigner: true, isWritable: false },
+    { pubkey: params.poolId, isSigner: false, isWritable: true },
+    { pubkey: params.lpMint, isSigner: false, isWritable: true },
+    { pubkey: params.userToken0, isSigner: false, isWritable: true },
+    { pubkey: params.userToken1, isSigner: false, isWritable: true },
+    { pubkey: params.userLp, isSigner: false, isWritable: true },
+    { pubkey: params.token0Vault, isSigner: false, isWritable: true },
+    { pubkey: params.token1Vault, isSigner: false, isWritable: true },
+    { pubkey: params.tokenProgram, isSigner: false, isWritable: false },
+  ];
+
+  const data = Buffer.concat([
+    DEPOSIT_LIQUIDITY_DISCRIMINATOR,
+    params.minLpAmount.toArrayLike(Buffer, 'le', 8),
+    params.maxToken0Amount.toArrayLike(Buffer, 'le', 8),
+    params.maxToken1Amount.toArrayLike(Buffer, 'le', 8),
+    params.poolId.toBuffer(),
+    Buffer.from([params.poolAuthorityBump]),
+  ]);
+
+  return new TransactionInstruction({
+    keys,
+    programId: CONTINUUM_PROGRAM_ID,
+    data,
+  });
+}
+
+export function createWithdrawLiquidityInstruction(params: WithdrawLiquidityParams): TransactionInstruction {
+  const [fifoState] = getFifoStatePDA();
+  const keys = [
+    { pubkey: fifoState, isSigner: false, isWritable: true },
+    { pubkey: params.cpSwapProgram, isSigner: false, isWritable: false },
+    { pubkey: params.owner, isSigner: true, isWritable: false },
+    { pubkey: params.poolId, isSigner: false, isWritable: true },
+    { pubkey: params.lpMint, isSigner: false, isWritable: true },
+    { pubkey: params.userToken0, isSigner: false, isWritable: true },
+    { pubkey: params.userToken1, isSigner: false, isWritable: true },
+    { pubkey: params.userLp, isSigner: false, isWritable: true },
+    { pubkey: params.token0Vault, isSigner: false, isWritable: true },
+    { pubkey: params.token1Vault, isSigner: false, isWritable: true },
+    { pubkey: params.tokenProgram, isSigner: false, isWritable: false },
+  ];
+
+  const data = Buffer.concat([
+    WITHDRAW_LIQUIDITY_DISCRIMINATOR,
+    params.lpAmount.toArrayLike(Buffer, 'le', 8),
+    params.minToken0Amount.toArrayLike(Buffer, 'le', 8),
+    params.minToken1Amount.toArrayLike(Buffer, 'le', 8),
+    params.poolId.toBuffer(),
+    Buffer.from([params.poolAuthorityBump]),
+  ]);
+
+  return new TransactionInstruction({
+    keys,
+    programId: CONTINUUM_PROGRAM_ID,
+    data,
+  });
+}

--- a/tests/lp-deposit-withdraw.test.ts
+++ b/tests/lp-deposit-withdraw.test.ts
@@ -1,0 +1,53 @@
+import { PublicKey, Keypair } from '@solana/web3.js';
+import BN from 'bn.js';
+import { expect } from 'chai';
+import {
+  createDepositLiquidityInstruction,
+  createWithdrawLiquidityInstruction,
+} from '../sdk/src/instructions';
+
+describe('LP deposit/withdraw instruction builders', () => {
+  const dummy = Keypair.generate().publicKey;
+
+  it('builds deposit liquidity wrapper instruction', () => {
+    const ix = createDepositLiquidityInstruction({
+      cpSwapProgram: dummy,
+      poolId: dummy,
+      minLpAmount: new BN(1),
+      maxToken0Amount: new BN(2),
+      maxToken1Amount: new BN(3),
+      poolAuthorityBump: 255,
+      owner: dummy,
+      lpMint: dummy,
+      userToken0: dummy,
+      userToken1: dummy,
+      userLp: dummy,
+      token0Vault: dummy,
+      token1Vault: dummy,
+      tokenProgram: dummy,
+    });
+    expect(ix.data.slice(0,8)).to.deep.equal(Buffer.from([245,99,59,25,151,71,233,249]));
+    expect(ix.keys.length).to.equal(11);
+  });
+
+  it('builds withdraw liquidity wrapper instruction', () => {
+    const ix = createWithdrawLiquidityInstruction({
+      cpSwapProgram: dummy,
+      poolId: dummy,
+      lpAmount: new BN(5),
+      minToken0Amount: new BN(6),
+      minToken1Amount: new BN(7),
+      poolAuthorityBump: 1,
+      owner: dummy,
+      lpMint: dummy,
+      userToken0: dummy,
+      userToken1: dummy,
+      userLp: dummy,
+      token0Vault: dummy,
+      token1Vault: dummy,
+      tokenProgram: dummy,
+    });
+    expect(ix.data.slice(0,8)).to.deep.equal(Buffer.from([149,158,33,185,47,243,253,31]));
+    expect(ix.keys.length).to.equal(11);
+  });
+});


### PR DESCRIPTION
## Summary
- add `DepositLiquidity` and `WithdrawLiquidity` CPI wrappers with Raydium discriminators
- expose new instructions in program and SDK
- add tests for building deposit/withdraw instructions

## Testing
- `cargo test -q`
- `npx ts-mocha -p tsconfig.json tests/lp-deposit-withdraw.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b06041d79083318645b636cc487101