### PR TITLE
Add deposit and withdraw CP-Swap wrapper

### DIFF
--- a/programs/continuum-cp-swap/src/instructions/deposit_lp.rs
+++ b/programs/continuum-cp-swap/src/instructions/deposit_lp.rs
@@ -1,0 +1,88 @@
+use crate::errors::ContinuumError;
+use crate::state::*;
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{
+    instruction::{AccountMeta, Instruction},
+    program::invoke_signed,
+};
+
+#[derive(Accounts)]
+pub struct DepositLp<'info> {
+    #[account(
+        mut,
+        seeds = [b"fifo_state"],
+        bump,
+        constraint = !fifo_state.emergency_pause @ ContinuumError::EmergencyPause,
+    )]
+    pub fifo_state: Account<'info, FifoState>,
+
+    /// CHECK: The CP-Swap program
+    pub cp_swap_program: UncheckedAccount<'info>,
+    // All other accounts (user, pool_state, token accounts, etc.)
+    // are passed through in remaining_accounts
+}
+
+pub fn deposit_lp<'info>(
+    ctx: Context<'_, '_, '_, 'info, DepositLp<'info>>,
+    min_lp_amount: u64,
+    max_amount_0: u64,
+    max_amount_1: u64,
+    pool_id: Pubkey,
+    pool_authority_bump: u8,
+) -> Result<()> {
+    let fifo_state = &mut ctx.accounts.fifo_state;
+    let sequence = fifo_state.current_sequence + 1;
+    fifo_state.current_sequence = sequence;
+
+    msg!("Deposit liquidity {} on pool {}", sequence, pool_id);
+
+    let mut ix_data = Vec::new();
+    // CP-Swap deposit discriminator
+    ix_data.extend_from_slice(&[242, 35, 198, 137, 82, 225, 242, 182]);
+    ix_data.extend_from_slice(&min_lp_amount.to_le_bytes());
+    ix_data.extend_from_slice(&max_amount_0.to_le_bytes());
+    ix_data.extend_from_slice(&max_amount_1.to_le_bytes());
+
+    let mut account_metas = vec![];
+    for (i, account) in ctx.remaining_accounts.iter().enumerate() {
+        if i == 0 {
+            account_metas.push(AccountMeta::new_readonly(account.key(), true));
+        } else if account.is_writable {
+            account_metas.push(AccountMeta::new(account.key(), false));
+        } else {
+            account_metas.push(AccountMeta::new_readonly(account.key(), false));
+        }
+    }
+
+    let ix = Instruction {
+        program_id: ctx.accounts.cp_swap_program.key(),
+        accounts: account_metas,
+        data: ix_data,
+    };
+
+    let pool_authority_seeds = &[
+        b"cp_pool_authority",
+        pool_id.as_ref(),
+        &[pool_authority_bump],
+    ];
+
+    let mut cpi_accounts = ctx.remaining_accounts.to_vec();
+    cpi_accounts.insert(0, ctx.accounts.cp_swap_program.to_account_info());
+
+    invoke_signed(&ix, &cpi_accounts, &[pool_authority_seeds])?;
+
+    emit!(LiquidityDeposited {
+        sequence,
+        pool_id,
+        min_lp_amount,
+    });
+
+    Ok(())
+}
+
+#[event]
+pub struct LiquidityDeposited {
+    pub sequence: u64,
+    pub pool_id: Pubkey,
+    pub min_lp_amount: u64,
+}

--- a/programs/continuum-cp-swap/src/instructions/mod.rs
+++ b/programs/continuum-cp-swap/src/instructions/mod.rs
@@ -1,15 +1,19 @@
+pub mod cancel_order;
+pub mod deposit_lp;
+pub mod execute_order;
 pub mod initialize;
 pub mod initialize_cp_swap_pool;
 pub mod submit_order;
 pub mod submit_order_simple;
-pub mod execute_order;
-pub mod cancel_order;
 pub mod swap_immediate;
+pub mod withdraw_lp;
 
+pub use cancel_order::*;
+pub use deposit_lp::*;
+pub use execute_order::*;
 pub use initialize::*;
 pub use initialize_cp_swap_pool::*;
 pub use submit_order::*;
 pub use submit_order_simple::*;
-pub use execute_order::*;
-pub use cancel_order::*;
 pub use swap_immediate::*;
+pub use withdraw_lp::*;

--- a/programs/continuum-cp-swap/src/instructions/swap_immediate.rs
+++ b/programs/continuum-cp-swap/src/instructions/swap_immediate.rs
@@ -1,10 +1,10 @@
+use crate::errors::ContinuumError;
+use crate::state::*;
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::{
+    instruction::{AccountMeta, Instruction},
     program::invoke_signed,
-    instruction::{Instruction, AccountMeta},
 };
-use crate::state::*;
-use crate::errors::ContinuumError;
 
 #[derive(Accounts)]
 pub struct SwapImmediate<'info> {
@@ -15,16 +15,15 @@ pub struct SwapImmediate<'info> {
         constraint = !fifo_state.emergency_pause @ ContinuumError::EmergencyPause,
     )]
     pub fifo_state: Account<'info, FifoState>,
-    
+
     /// CHECK: The CP-Swap program
     pub cp_swap_program: UncheckedAccount<'info>,
-    
-    // All other accounts (user, pool_authority, pool_id, user accounts, etc.) 
+    // All other accounts (user, pool_authority, pool_id, user accounts, etc.)
     // are passed through in remaining_accounts to avoid deserialization
 }
 
-pub fn swap_immediate(
-    ctx: Context<SwapImmediate>,
+pub fn swap_immediate<'info>(
+    ctx: Context<'_, '_, '_, 'info, SwapImmediate<'info>>,
     amount_in: u64,
     min_amount_out: u64,
     is_base_input: bool,
@@ -32,28 +31,28 @@ pub fn swap_immediate(
     pool_authority_bump: u8,
 ) -> Result<()> {
     let fifo_state = &mut ctx.accounts.fifo_state;
-    
+
     // Increment sequence for tracking
     let sequence = fifo_state.current_sequence + 1;
     fifo_state.current_sequence = sequence;
-    
+
     msg!("Immediate swap {} on pool {}", sequence, pool_id);
-    
+
     // Build the swap instruction data
     let mut ix_data = Vec::new();
-    
+
     // IMPORTANT: We now use swap_base_input for both directions to maintain consistent semantics
     // This gives us "I have exactly X tokens, give me at least Y tokens" behavior regardless of direction
-    
+
     // Always use swap_base_input discriminator
-    ix_data.extend_from_slice(&[143, 190, 90, 218, 196, 30, 51, 222]); 
-    ix_data.extend_from_slice(&amount_in.to_le_bytes());      // exact tokens to swap
+    ix_data.extend_from_slice(&[143, 190, 90, 218, 196, 30, 51, 222]);
+    ix_data.extend_from_slice(&amount_in.to_le_bytes()); // exact tokens to swap
     ix_data.extend_from_slice(&min_amount_out.to_le_bytes()); // minimum tokens to receive
-    
+
     // Build account metas from remaining accounts
     // The client must pass accounts in the correct order for CP-Swap
     let mut account_metas = vec![];
-    
+
     // Add all remaining accounts as they were passed
     for (i, account) in ctx.remaining_accounts.iter().enumerate() {
         // First account should be the user (payer for CP-Swap)
@@ -67,41 +66,41 @@ pub fn swap_immediate(
             });
         }
     }
-    
+
     // Create the instruction
     let ix = Instruction {
         program_id: ctx.accounts.cp_swap_program.key(),
         accounts: account_metas,
         data: ix_data,
     };
-    
+
     // Invoke CP-Swap with pool authority signer
     let pool_authority_seeds = &[
         b"cp_pool_authority",
         pool_id.as_ref(),
         &[pool_authority_bump],
     ];
-    
+
     // Build accounts array for CPI, including the cp_swap_program
-    let mut cpi_accounts = vec![ctx.accounts.cp_swap_program.to_account_info()];
-    cpi_accounts.extend(ctx.remaining_accounts.iter().cloned());
-    
+    let cp_swap_program = ctx.accounts.cp_swap_program.to_account_info();
+    let remaining_accounts: Vec<AccountInfo<'_>> =
+        ctx.remaining_accounts.iter().map(|a| a.to_account_info()).collect();
+    let mut cpi_accounts: Vec<AccountInfo<'_>> = Vec::with_capacity(remaining_accounts.len() + 1);
+    cpi_accounts.push(cp_swap_program);
+    cpi_accounts.extend(remaining_accounts);
+
     // Pass all accounts to invoke_signed
-    invoke_signed(
-        &ix,
-        &cpi_accounts,
-        &[pool_authority_seeds],
-    )?;
-    
+    invoke_signed(&ix, &cpi_accounts, &[pool_authority_seeds])?;
+
     emit!(SwapExecuted {
         sequence,
         pool_id,
         amount_in,
         is_base_input, // Note: This parameter is now only used for logging, not for routing
     });
-    
+
     msg!("Swap {} executed successfully", sequence);
-    
+
     Ok(())
 }
 

--- a/programs/continuum-cp-swap/src/instructions/withdraw_lp.rs
+++ b/programs/continuum-cp-swap/src/instructions/withdraw_lp.rs
@@ -1,0 +1,91 @@
+use crate::errors::ContinuumError;
+use crate::state::*;
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{
+    instruction::{AccountMeta, Instruction},
+    program::invoke_signed,
+};
+
+#[derive(Accounts)]
+pub struct WithdrawLp<'info> {
+    #[account(
+        mut,
+        seeds = [b"fifo_state"],
+        bump,
+        constraint = !fifo_state.emergency_pause @ ContinuumError::EmergencyPause,
+    )]
+    pub fifo_state: Account<'info, FifoState>,
+
+    /// CHECK: The CP-Swap program
+    pub cp_swap_program: UncheckedAccount<'info>,
+    // All other accounts are passed through in remaining_accounts
+}
+
+pub fn withdraw_lp<'info>(
+    ctx: Context<'_, '_, '_, 'info, WithdrawLp<'info>>,
+    lp_amount: u64,
+    min_amount_0: u64,
+    min_amount_1: u64,
+    pool_id: Pubkey,
+    pool_authority_bump: u8,
+) -> Result<()> {
+    let fifo_state = &mut ctx.accounts.fifo_state;
+    let sequence = fifo_state.current_sequence + 1;
+    fifo_state.current_sequence = sequence;
+
+    msg!("Withdraw liquidity {} from pool {}", sequence, pool_id);
+
+    let mut ix_data = Vec::new();
+    // CP-Swap withdraw discriminator
+    ix_data.extend_from_slice(&[183, 18, 70, 156, 148, 109, 161, 34]);
+    ix_data.extend_from_slice(&lp_amount.to_le_bytes());
+    ix_data.extend_from_slice(&min_amount_0.to_le_bytes());
+    ix_data.extend_from_slice(&min_amount_1.to_le_bytes());
+
+    let mut account_metas = vec![];
+    for (i, account) in ctx.remaining_accounts.iter().enumerate() {
+        if i == 0 {
+            account_metas.push(AccountMeta::new_readonly(account.key(), true));
+        } else if account.is_writable {
+            account_metas.push(AccountMeta::new(account.key(), false));
+        } else {
+            account_metas.push(AccountMeta::new_readonly(account.key(), false));
+        }
+    }
+
+    let ix = Instruction {
+        program_id: ctx.accounts.cp_swap_program.key(),
+        accounts: account_metas,
+        data: ix_data,
+    };
+
+    let pool_authority_seeds = &[
+        b"cp_pool_authority",
+        pool_id.as_ref(),
+        &[pool_authority_bump],
+    ];
+
+    let cp_swap_program = ctx.accounts.cp_swap_program.to_account_info();
+    let remaining_accounts: Vec<AccountInfo<'_>> =
+        ctx.remaining_accounts.iter().map(|a| a.to_account_info()).collect();
+    let mut cpi_accounts: Vec<AccountInfo<'_>> = Vec::with_capacity(remaining_accounts.len() + 1);
+    cpi_accounts.push(cp_swap_program);
+    cpi_accounts.extend(remaining_accounts);
+
+    invoke_signed(&ix, &cpi_accounts, &[pool_authority_seeds])?;
+
+    emit!(LiquidityWithdrawn {
+        sequence,
+        pool_id,
+        lp_amount,
+    });
+
+    Ok(())
+}
+
+#[event]
+pub struct LiquidityWithdrawn {
+    pub sequence: u64,
+    pub pool_id: Pubkey,
+    pub lp_amount: u64,
+}

--- a/programs/continuum-cp-swap/src/lib.rs
+++ b/programs/continuum-cp-swap/src/lib.rs
@@ -38,17 +38,12 @@ pub mod continuum_cp_swap {
     }
 
     /// Execute the next order in the FIFO queue
-    pub fn execute_order(
-        ctx: Context<ExecuteOrder>,
-        expected_sequence: u64,
-    ) -> Result<()> {
+    pub fn execute_order(ctx: Context<ExecuteOrder>, expected_sequence: u64) -> Result<()> {
         instructions::execute_order(ctx, expected_sequence)
     }
 
     /// Cancel an order (only by original submitter)
-    pub fn cancel_order(
-        ctx: Context<CancelOrder>,
-    ) -> Result<()> {
+    pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
         instructions::cancel_order(ctx)
     }
 
@@ -71,6 +66,51 @@ pub mod continuum_cp_swap {
         pool_id: Pubkey,
         pool_authority_bump: u8,
     ) -> Result<()> {
-        instructions::swap_immediate(ctx, amount_in, min_amount_out, is_base_input, pool_id, pool_authority_bump)
+        instructions::swap_immediate(
+            ctx,
+            amount_in,
+            min_amount_out,
+            is_base_input,
+            pool_id,
+            pool_authority_bump,
+        )
+    }
+
+    /// Deposit liquidity into a CP-Swap pool
+    pub fn deposit_lp(
+        ctx: Context<DepositLp>,
+        min_lp_amount: u64,
+        max_amount_0: u64,
+        max_amount_1: u64,
+        pool_id: Pubkey,
+        pool_authority_bump: u8,
+    ) -> Result<()> {
+        instructions::deposit_lp(
+            ctx,
+            min_lp_amount,
+            max_amount_0,
+            max_amount_1,
+            pool_id,
+            pool_authority_bump,
+        )
+    }
+
+    /// Withdraw liquidity from a CP-Swap pool
+    pub fn withdraw_lp(
+        ctx: Context<WithdrawLp>,
+        lp_amount: u64,
+        min_amount_0: u64,
+        min_amount_1: u64,
+        pool_id: Pubkey,
+        pool_authority_bump: u8,
+    ) -> Result<()> {
+        instructions::withdraw_lp(
+            ctx,
+            lp_amount,
+            min_amount_0,
+            min_amount_1,
+            pool_id,
+            pool_authority_bump,
+        )
     }
 }

--- a/sdk/src/instructions/depositLp.ts
+++ b/sdk/src/instructions/depositLp.ts
@@ -1,0 +1,59 @@
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import BN from 'bn.js';
+import { CONTINUUM_PROGRAM_ID } from '../constants';
+import { getFifoStatePDA } from '../utils';
+
+export interface DepositLpParams {
+  user: PublicKey;
+  cpSwapProgram: PublicKey;
+  poolId: PublicKey;
+  minLpAmount: BN;
+  maxAmount0: BN;
+  maxAmount1: BN;
+  poolAuthorityBump: number;
+  remainingAccounts: Array<{
+    pubkey: PublicKey;
+    isSigner: boolean;
+    isWritable: boolean;
+  }>;
+}
+
+export function createDepositLpInstruction(
+  params: DepositLpParams
+): TransactionInstruction {
+  const {
+    user,
+    cpSwapProgram,
+    poolId,
+    minLpAmount,
+    maxAmount0,
+    maxAmount1,
+    poolAuthorityBump,
+    remainingAccounts
+  } = params;
+
+  const [fifoState] = getFifoStatePDA();
+
+  const keys = [
+    { pubkey: fifoState, isSigner: false, isWritable: true },
+    { pubkey: cpSwapProgram, isSigner: false, isWritable: false },
+    ...remainingAccounts
+  ];
+
+  const discriminator = Buffer.from([83, 107, 16, 26, 26, 20, 130, 56]);
+
+  const data = Buffer.concat([
+    discriminator,
+    minLpAmount.toArrayLike(Buffer, 'le', 8),
+    maxAmount0.toArrayLike(Buffer, 'le', 8),
+    maxAmount1.toArrayLike(Buffer, 'le', 8),
+    poolId.toBuffer(),
+    Buffer.from([poolAuthorityBump])
+  ]);
+
+  return new TransactionInstruction({
+    keys,
+    programId: CONTINUUM_PROGRAM_ID,
+    data
+  });
+}

--- a/sdk/src/instructions/index.ts
+++ b/sdk/src/instructions/index.ts
@@ -4,3 +4,5 @@ export * from './submitOrder';
 export * from './executeOrder';
 export * from './cancelOrder';
 export * from './swapImmediate';
+export * from './depositLp';
+export * from './withdrawLp';

--- a/sdk/src/instructions/withdrawLp.ts
+++ b/sdk/src/instructions/withdrawLp.ts
@@ -1,0 +1,59 @@
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import BN from 'bn.js';
+import { CONTINUUM_PROGRAM_ID } from '../constants';
+import { getFifoStatePDA } from '../utils';
+
+export interface WithdrawLpParams {
+  user: PublicKey;
+  cpSwapProgram: PublicKey;
+  poolId: PublicKey;
+  lpAmount: BN;
+  minAmount0: BN;
+  minAmount1: BN;
+  poolAuthorityBump: number;
+  remainingAccounts: Array<{
+    pubkey: PublicKey;
+    isSigner: boolean;
+    isWritable: boolean;
+  }>;
+}
+
+export function createWithdrawLpInstruction(
+  params: WithdrawLpParams
+): TransactionInstruction {
+  const {
+    user,
+    cpSwapProgram,
+    poolId,
+    lpAmount,
+    minAmount0,
+    minAmount1,
+    poolAuthorityBump,
+    remainingAccounts
+  } = params;
+
+  const [fifoState] = getFifoStatePDA();
+
+  const keys = [
+    { pubkey: fifoState, isSigner: false, isWritable: true },
+    { pubkey: cpSwapProgram, isSigner: false, isWritable: false },
+    ...remainingAccounts
+  ];
+
+  const discriminator = Buffer.from([225, 221, 45, 211, 49, 60, 51, 163]);
+
+  const data = Buffer.concat([
+    discriminator,
+    lpAmount.toArrayLike(Buffer, 'le', 8),
+    minAmount0.toArrayLike(Buffer, 'le', 8),
+    minAmount1.toArrayLike(Buffer, 'le', 8),
+    poolId.toBuffer(),
+    Buffer.from([poolAuthorityBump])
+  ]);
+
+  return new TransactionInstruction({
+    keys,
+    programId: CONTINUUM_PROGRAM_ID,
+    data
+  });
+}


### PR DESCRIPTION
## Summary
- add deposit_lp and withdraw_lp instructions that forward accounts and sign with pool authority PDA
- export new instructions in module and program entrypoints
- add TypeScript helpers for deposit and withdraw wrappers

## Testing
- `cargo test` *(fails: lifetime may not live long enough)*
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b06067b0908331a9673b7adbd621f3