### PR TITLE
Add devnet helper scripts for CTM wrapper

### DIFF
--- a/config/devnet-pool.json
+++ b/config/devnet-pool.json
@@ -1,0 +1,20 @@
+{
+  "network": "devnet",
+  "createdAt": "2025-09-20T09:26:35.839Z",
+  "creator": "BpEz2agzXJFb2mr3WrVR45Hga88c6G2L7YJAbbyXdanb",
+  "poolId": "9uRP7dQoqaQ8k6ACu2nNUFz3QajQujM8J7ohXaWCn7wi",
+  "ammConfig": "5XoBUe5w3xSjRMgaPSwyA2ujH7eBBH5nD5L9H2ws841B",
+  "token0Mint": "7w9zFL3fT2LNogZHrbpq2h2KvUGZAh37iyuuhH8bJRtf",
+  "token1Mint": "F6pomBd1E4au6cZunLLFbL2bzu5o6gfpuptsaWoqywnL",
+  "token0Vault": "2tKWJmLMejqUy7KP8ug4G4wAhGEwsJSacuqUJuBejU1f",
+  "token1Vault": "Attzzn7qoQbj9668P7Lb6Abvf4cAX1tjn2c5iMZ7zYrq",
+  "lpMint": "8dNsEPQPhfNGVYjhTCBuES351nHyX9MYVSkyxcngShHF",
+  "observationState": "CjjadAjL7jibDFWtvKPF3pzrR52oPsQbtj91s7BQEqRb",
+  "continuumAuthority": "8HG3PQBKTxZe8m9ysZqzk54wEjVKA7swhK2qYf76csvR",
+  "continuumAuthorityBump": 254,
+  "cpSwapAuthority": "EwXTC3iX6iKHtXMfZkmWt4yDgB6aWCrczvRtfKWVoouu",
+  "initAmount0": "100000000000",
+  "initAmount1": "100000000",
+  "cpSwapProgram": "GkenxCtvEabZrwFf15D3E6LjoZTywH2afNwiqDwthyDp",
+  "continuumProgram": "EmCthKmtC2B6xXKF9uYxo9EF5C5zJjbYvUMW3VrhFXX3"
+}

--- a/config/devnet-tokens.json
+++ b/config/devnet-tokens.json
@@ -1,0 +1,19 @@
+{
+  "network": "devnet",
+  "owner": "BpEz2agzXJFb2mr3WrVR45Hga88c6G2L7YJAbbyXdanb",
+  "createdAt": "2025-09-20T09:25:29.940Z",
+  "tokenA": {
+    "mint": "F6pomBd1E4au6cZunLLFbL2bzu5o6gfpuptsaWoqywnL",
+    "decimals": 6,
+    "account": "HdBCyrRdjMzZoq38xVz39C6STA15FDKKrpCvPdvVy37Y",
+    "amount": "1000000000000",
+    "symbol": "TOKENA"
+  },
+  "tokenB": {
+    "mint": "7w9zFL3fT2LNogZHrbpq2h2KvUGZAh37iyuuhH8bJRtf",
+    "decimals": 9,
+    "account": "Ch1hRNRmWnj6is8pKCsfHK8dxZXYENUeQWwWHQtVjKKy",
+    "amount": "1000000000000",
+    "symbol": "TOKENB"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
       "license": "ISC",
       "dependencies": {
         "@coral-xyz/anchor": "^0.31.1",
-        "decimal.js": "^10.6.0"
+        "decimal.js": "^10.6.0",
+        "tweetnacl": "^1.0.3",
+        "undici": "^6.19.8"
       },
       "devDependencies": {
         "@solana/spl-token": "^0.4.13",
@@ -2462,6 +2464,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -2483,6 +2491,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.1",
-    "decimal.js": "^10.6.0"
+    "decimal.js": "^10.6.0",
+    "tweetnacl": "^1.0.3",
+    "undici": "^6.19.8"
   },
   "devDependencies": {
     "@solana/spl-token": "^0.4.13",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -819,9 +819,9 @@ We provide three end-to-end helper scripts under `sdk/examples` that orchestrate
    npx ts-node sdk/examples/devnet-lp-operations.ts
    ```
 
-   Uses the SDK builders (`createDepositLpInstruction` / `createWithdrawLpInstruction`) to send liquidity through the CTM wrapper and then withdraw half of the received LP tokens, printing post-operation balances for verification.
+   Prefunds the CTM wrapper's pool-authority token accounts, computes the proportional LP to mint, submits the deposit through `createDepositLpInstruction`, and finally withdraws the newly minted LP position back into the CTM custody account for inspection. The script prints both Continuum-controlled and user balances after each step so you can verify the round trip.
 
-All scripts default to the keypair located at `~/.config/solana/id.json`; set `KEYPAIR=/path/to/keypair.json` to override. They assume the CTM FIFO state has been initialised on devnet.
+All scripts default to the keypair located at `~/.config/solana/id.json`; set `KEYPAIR=/path/to/keypair.json` to override. They assume the CTM FIFO state has been initialised on devnet. When running behind certain proxies you may need to prefix commands with `NODE_OPTIONS=--dns-result-order=ipv4first` so that `ts-node` resolves the RPC endpoint correctly.
 
 ### 2. Price Feed Integration
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -793,6 +793,36 @@ async function performSwap() {
 }
 ```
 
+### 3. Devnet Helper Scripts
+
+We provide three end-to-end helper scripts under `sdk/examples` that orchestrate the full devnet flow with the deployed Continuum (`EmCthKmtC2B6xXKF9uYxo9EF5C5zJjbYvUMW3VrhFXX3`) and Raydium CP-Swap (`GkenxCtvEabZrwFf15D3E6LjoZTywH2afNwiqDwthyDp`) programs:
+
+1. **Create fresh devnet mints**
+
+   ```bash
+   npx ts-node sdk/examples/devnet-create-mints.ts
+   ```
+
+   Creates two SPL token mints, mints an initial supply to your wallet, and writes the result to `config/devnet-tokens.json` for subsequent steps.
+
+2. **Initialise a protected CP-Swap pool**
+
+   ```bash
+   npx ts-node sdk/examples/devnet-init-pool.ts
+   ```
+
+   Derives a new AMM config (creating it if necessary), sets the CTM wrapper PDA as custom authority, and deploys a Raydium pool using the freshly minted tokens. The pool configuration is saved to `config/devnet-pool.json`.
+
+3. **Deposit and withdraw liquidity through CTM**
+
+   ```bash
+   npx ts-node sdk/examples/devnet-lp-operations.ts
+   ```
+
+   Uses the SDK builders (`createDepositLpInstruction` / `createWithdrawLpInstruction`) to send liquidity through the CTM wrapper and then withdraw half of the received LP tokens, printing post-operation balances for verification.
+
+All scripts default to the keypair located at `~/.config/solana/id.json`; set `KEYPAIR=/path/to/keypair.json` to override. They assume the CTM FIFO state has been initialised on devnet.
+
 ### 2. Price Feed Integration
 
 ```typescript

--- a/sdk/examples/devnet-create-mints.ts
+++ b/sdk/examples/devnet-create-mints.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env ts-node
+
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  Transaction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js';
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountInstruction,
+  createMint,
+  getAccount,
+  getAssociatedTokenAddress,
+  mintTo,
+} from '@solana/spl-token';
+import fs from 'fs';
+import path from 'path';
+
+const DEVNET_RPC = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
+const DEFAULT_KEYPAIR_PATH = path.join(process.env.HOME ?? '.', '.config/solana/id.json');
+const OUTPUT_PATH = path.join(__dirname, '../../config/devnet-tokens.json');
+
+interface TokenInfo {
+  mint: string;
+  decimals: number;
+  account: string;
+  amount: string;
+  symbol: string;
+}
+
+interface TokenConfigFile {
+  network: 'devnet';
+  owner: string;
+  createdAt: string;
+  tokenA: TokenInfo;
+  tokenB: TokenInfo;
+}
+
+async function airdropIfNeeded(connection: Connection, wallet: PublicKey, minimumLamports: number) {
+  const current = await connection.getBalance(wallet);
+  if (current >= minimumLamports) {
+    return;
+  }
+
+  try {
+    const sig = await connection.requestAirdrop(wallet, Math.max(minimumLamports - current, 1 * LAMPORTS_PER_SOL));
+    await connection.confirmTransaction(sig, 'confirmed');
+    console.log(`💧 Airdropped SOL to ${wallet.toBase58()}`);
+  } catch (err) {
+    console.warn('⚠️  Unable to request airdrop:', err);
+  }
+}
+
+async function createMintIfNeeded(
+  connection: Connection,
+  payer: Keypair,
+  decimals: number,
+  symbol: string,
+  initialAmount: bigint,
+): Promise<TokenInfo> {
+  const mint = await createMint(connection, payer, payer.publicKey, payer.publicKey, decimals, undefined, undefined, TOKEN_PROGRAM_ID);
+  console.log(`✅ Created ${symbol} mint: ${mint.toBase58()}`);
+
+  const ata = await getAssociatedTokenAddress(mint, payer.publicKey);
+  const ataInfo = await connection.getAccountInfo(ata);
+  if (!ataInfo) {
+    const createAtaIx = createAssociatedTokenAccountInstruction(
+      payer.publicKey,
+      ata,
+      payer.publicKey,
+      mint,
+      TOKEN_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+    );
+    const createAtaTx = new Transaction().add(createAtaIx);
+    const createAtaSig = await sendAndConfirmTransaction(connection, createAtaTx, [payer]);
+    console.log(`   → Created ATA (${symbol}): ${ata.toBase58()} (${createAtaSig})`);
+  }
+
+  await mintTo(connection, payer, mint, ata, payer.publicKey, Number(initialAmount));
+  const accountInfo = await getAccount(connection, ata);
+  console.log(`   → Minted ${(Number(accountInfo.amount) / 10 ** decimals).toLocaleString()} ${symbol}`);
+
+  return {
+    mint: mint.toBase58(),
+    decimals,
+    account: ata.toBase58(),
+    amount: accountInfo.amount.toString(),
+    symbol,
+  };
+}
+
+async function main() {
+  const keypairPath = process.env.KEYPAIR ?? DEFAULT_KEYPAIR_PATH;
+  if (!fs.existsSync(keypairPath)) {
+    throw new Error(`Keypair file not found at ${keypairPath}`);
+  }
+
+  const secret = JSON.parse(fs.readFileSync(keypairPath, 'utf8')) as number[];
+  const payer = Keypair.fromSecretKey(new Uint8Array(secret));
+
+  const connection = new Connection(DEVNET_RPC, 'confirmed');
+  console.log('🌐 RPC Endpoint:', DEVNET_RPC);
+  console.log('🔑 Payer:', payer.publicKey.toBase58());
+
+  await airdropIfNeeded(connection, payer.publicKey, 2 * LAMPORTS_PER_SOL);
+
+  const tokenA = await createMintIfNeeded(connection, payer, 6, 'TOKENA', 1_000_000n * 1_000_000n);
+  const tokenB = await createMintIfNeeded(connection, payer, 9, 'TOKENB', 1_000n * 1_000_000_000n);
+
+  const payload: TokenConfigFile = {
+    network: 'devnet',
+    owner: payer.publicKey.toBase58(),
+    createdAt: new Date().toISOString(),
+    tokenA,
+    tokenB,
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(payload, null, 2));
+  console.log(`\n📝 Saved token configuration to ${OUTPUT_PATH}`);
+}
+
+main().catch(err => {
+  console.error('❌ Failed to create token mints:', err);
+  process.exit(1);
+});

--- a/sdk/examples/devnet-create-mints.ts
+++ b/sdk/examples/devnet-create-mints.ts
@@ -5,20 +5,26 @@ import {
   Keypair,
   LAMPORTS_PER_SOL,
   PublicKey,
+  SystemProgram,
   Transaction,
-  sendAndConfirmTransaction,
 } from '@solana/web3.js';
 import {
-  ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
-  createAssociatedTokenAccountInstruction,
-  createMint,
+  MINT_SIZE,
+  createInitializeMint2Instruction,
+  createMintToInstruction,
   getAccount,
-  getAssociatedTokenAddress,
-  mintTo,
+  getMinimumBalanceForRentExemptMint,
 } from '@solana/spl-token';
 import fs from 'fs';
 import path from 'path';
+import {
+  confirmSignature,
+  createHttpConnection,
+  ensureAta,
+  loadOrGenerateKeypair,
+  sendTransactionWithRetry,
+} from './utils';
 
 const DEVNET_RPC = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
 const DEFAULT_KEYPAIR_PATH = path.join(process.env.HOME ?? '.', '.config/solana/id.json');
@@ -41,52 +47,72 @@ interface TokenConfigFile {
 }
 
 async function airdropIfNeeded(connection: Connection, wallet: PublicKey, minimumLamports: number) {
-  const current = await connection.getBalance(wallet);
+  const current = await connection.getBalance(wallet, 'confirmed');
   if (current >= minimumLamports) {
     return;
   }
 
   try {
-    const sig = await connection.requestAirdrop(wallet, Math.max(minimumLamports - current, 1 * LAMPORTS_PER_SOL));
-    await connection.confirmTransaction(sig, 'confirmed');
+    const amount = Math.max(minimumLamports - current, 1 * LAMPORTS_PER_SOL);
+    const sig = await connection.requestAirdrop(wallet, amount);
+    await confirmSignature(connection, sig);
     console.log(`💧 Airdropped SOL to ${wallet.toBase58()}`);
   } catch (err) {
     console.warn('⚠️  Unable to request airdrop:', err);
   }
 }
 
-async function createMintIfNeeded(
+async function createMintAndSeed(
   connection: Connection,
   payer: Keypair,
   decimals: number,
   symbol: string,
-  initialAmount: bigint,
+  initialAmount: number,
 ): Promise<TokenInfo> {
-  const mint = await createMint(connection, payer, payer.publicKey, payer.publicKey, decimals, undefined, undefined, TOKEN_PROGRAM_ID);
-  console.log(`✅ Created ${symbol} mint: ${mint.toBase58()}`);
+  const mintKeypair = Keypair.generate();
+  const rent = await getMinimumBalanceForRentExemptMint(connection, 'confirmed');
 
-  const ata = await getAssociatedTokenAddress(mint, payer.publicKey);
-  const ataInfo = await connection.getAccountInfo(ata);
-  if (!ataInfo) {
-    const createAtaIx = createAssociatedTokenAccountInstruction(
+  const createMintTx = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: mintKeypair.publicKey,
+      space: MINT_SIZE,
+      lamports: rent,
+      programId: TOKEN_PROGRAM_ID,
+    }),
+    createInitializeMint2Instruction(
+      mintKeypair.publicKey,
+      decimals,
       payer.publicKey,
+      payer.publicKey,
+      TOKEN_PROGRAM_ID,
+    ),
+  );
+
+  const createMintSig = await sendTransactionWithRetry(connection, createMintTx, [payer, mintKeypair]);
+  console.log(`✅ Created ${symbol} mint: ${mintKeypair.publicKey.toBase58()} (${createMintSig})`);
+
+  const ata = await ensureAta(connection, payer, payer.publicKey, mintKeypair.publicKey);
+
+  const mintTx = new Transaction().add(
+    createMintToInstruction(
+      mintKeypair.publicKey,
       ata,
       payer.publicKey,
-      mint,
+      initialAmount,
+      [],
       TOKEN_PROGRAM_ID,
-      ASSOCIATED_TOKEN_PROGRAM_ID,
-    );
-    const createAtaTx = new Transaction().add(createAtaIx);
-    const createAtaSig = await sendAndConfirmTransaction(connection, createAtaTx, [payer]);
-    console.log(`   → Created ATA (${symbol}): ${ata.toBase58()} (${createAtaSig})`);
-  }
+    ),
+  );
+  const mintSig = await sendTransactionWithRetry(connection, mintTx, [payer]);
+  console.log(
+    `   → Minted ${(initialAmount / 10 ** decimals).toLocaleString()} ${symbol} (${mintSig})`,
+  );
 
-  await mintTo(connection, payer, mint, ata, payer.publicKey, Number(initialAmount));
-  const accountInfo = await getAccount(connection, ata);
-  console.log(`   → Minted ${(Number(accountInfo.amount) / 10 ** decimals).toLocaleString()} ${symbol}`);
+  const accountInfo = await getAccount(connection, ata, 'confirmed');
 
   return {
-    mint: mint.toBase58(),
+    mint: mintKeypair.publicKey.toBase58(),
     decimals,
     account: ata.toBase58(),
     amount: accountInfo.amount.toString(),
@@ -96,21 +122,16 @@ async function createMintIfNeeded(
 
 async function main() {
   const keypairPath = process.env.KEYPAIR ?? DEFAULT_KEYPAIR_PATH;
-  if (!fs.existsSync(keypairPath)) {
-    throw new Error(`Keypair file not found at ${keypairPath}`);
-  }
+  const payer = loadOrGenerateKeypair(keypairPath);
 
-  const secret = JSON.parse(fs.readFileSync(keypairPath, 'utf8')) as number[];
-  const payer = Keypair.fromSecretKey(new Uint8Array(secret));
-
-  const connection = new Connection(DEVNET_RPC, 'confirmed');
+  const connection = createHttpConnection(DEVNET_RPC, 'confirmed');
   console.log('🌐 RPC Endpoint:', DEVNET_RPC);
   console.log('🔑 Payer:', payer.publicKey.toBase58());
 
   await airdropIfNeeded(connection, payer.publicKey, 2 * LAMPORTS_PER_SOL);
 
-  const tokenA = await createMintIfNeeded(connection, payer, 6, 'TOKENA', 1_000_000n * 1_000_000n);
-  const tokenB = await createMintIfNeeded(connection, payer, 9, 'TOKENB', 1_000n * 1_000_000_000n);
+  const tokenA = await createMintAndSeed(connection, payer, 6, 'TOKENA', 1_000_000 * 1_000_000);
+  const tokenB = await createMintAndSeed(connection, payer, 9, 'TOKENB', 1_000 * 1_000_000_000);
 
   const payload: TokenConfigFile = {
     network: 'devnet',

--- a/sdk/examples/devnet-init-pool.ts
+++ b/sdk/examples/devnet-init-pool.ts
@@ -1,20 +1,13 @@
 #!/usr/bin/env ts-node
 
 import {
-  Connection,
   Keypair,
   PublicKey,
   SystemProgram,
   Transaction,
   TransactionInstruction,
-  sendAndConfirmTransaction,
 } from '@solana/web3.js';
-import {
-  ASSOCIATED_TOKEN_PROGRAM_ID,
-  TOKEN_PROGRAM_ID,
-  createAssociatedTokenAccountInstruction,
-  getAssociatedTokenAddress,
-} from '@solana/spl-token';
+import { getAssociatedTokenAddress } from '@solana/spl-token';
 import BN from 'bn.js';
 import fs from 'fs';
 import path from 'path';
@@ -25,14 +18,19 @@ import {
   createInitializeCpSwapPoolDirectInstruction,
   getCpSwapPDAs,
 } from '../src/instructions/initializeCpSwapPoolDirect';
+import {
+  createHttpConnection,
+  ensureAta,
+  loadOrGenerateKeypair,
+  sendTransactionWithRetry,
+} from './utils';
 
 const DEVNET_RPC = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
 const DEFAULT_KEYPAIR_PATH = path.join(process.env.HOME ?? '.', '.config/solana/id.json');
 const TOKENS_PATH = path.join(__dirname, '../../config/devnet-tokens.json');
 const OUTPUT_PATH = path.join(__dirname, '../../config/devnet-pool.json');
 
-const DEFAULT_FEE_OWNER = new PublicKey('GsV1jugD8ftfWBYNykA9SLK2V4mQqUW2sLop8MAfjVRq');
-const AMM_CONFIG_INDEX = Number(process.env.AMM_CONFIG_INDEX ?? 42);
+const AMM_CONFIG_INDEX = Number(process.env.AMM_CONFIG_INDEX ?? 0);
 const TRADE_FEE_BPS = Number(process.env.TRADE_FEE_BPS ?? 2500);
 const PROTOCOL_FEE_BPS = Number(process.env.PROTOCOL_FEE_BPS ?? 0);
 const FUND_FEE_BPS = Number(process.env.FUND_FEE_BPS ?? 0);
@@ -45,9 +43,22 @@ interface TokenConfigFile {
   tokenB: { mint: string; decimals: number; symbol: string; account: string };
 }
 
+function findTokenDecimals(tokens: TokenConfigFile, mint: PublicKey): number {
+  if (tokens.tokenA.mint === mint.toBase58()) {
+    return tokens.tokenA.decimals;
+  }
+  if (tokens.tokenB.mint === mint.toBase58()) {
+    return tokens.tokenB.decimals;
+  }
+  throw new Error(`Unable to determine decimals for mint ${mint.toBase58()}`);
+}
+
+function amountWithDecimals(amount: number, decimals: number): BN {
+  return new BN(amount).mul(new BN(10).pow(new BN(decimals)));
+}
+
 function deriveAmmConfigPda(index: number): [PublicKey, number] {
-  const indexBuffer = Buffer.alloc(2);
-  indexBuffer.writeUInt16LE(index);
+  const indexBuffer = new BN(index).toArrayLike(Buffer, 'be', 2);
   return PublicKey.findProgramAddressSync(
     [Buffer.from('amm_config'), indexBuffer],
     CP_SWAP_PROGRAM_ID,
@@ -55,13 +66,14 @@ function deriveAmmConfigPda(index: number): [PublicKey, number] {
 }
 
 function createAmmConfigInstruction(owner: PublicKey, ammConfig: PublicKey): TransactionInstruction {
+  const discriminator = Buffer.from([137, 52, 237, 212, 215, 117, 108, 104]);
   const data = Buffer.concat([
-    Buffer.from([72, 186, 156, 243, 103, 195, 75, 79]),
-    Buffer.from([AMM_CONFIG_INDEX & 0xff]),
-    new BN(TICK_SPACING).toArrayLike(Buffer, 'le', 2),
-    new BN(TRADE_FEE_BPS).toArrayLike(Buffer, 'le', 4),
-    new BN(PROTOCOL_FEE_BPS).toArrayLike(Buffer, 'le', 4),
-    new BN(FUND_FEE_BPS).toArrayLike(Buffer, 'le', 4),
+    discriminator,
+    new BN(AMM_CONFIG_INDEX).toArrayLike(Buffer, 'le', 2),
+    new BN(TRADE_FEE_BPS).toArrayLike(Buffer, 'le', 8),
+    new BN(PROTOCOL_FEE_BPS).toArrayLike(Buffer, 'le', 8),
+    new BN(FUND_FEE_BPS).toArrayLike(Buffer, 'le', 8),
+    new BN(0).toArrayLike(Buffer, 'le', 8),
   ]);
 
   return new TransactionInstruction({
@@ -75,46 +87,23 @@ function createAmmConfigInstruction(owner: PublicKey, ammConfig: PublicKey): Tra
   });
 }
 
-async function ensureAta(
-  connection: Connection,
-  payer: Keypair,
-  owner: PublicKey,
-  mint: PublicKey,
-): Promise<PublicKey> {
-  const ata = await getAssociatedTokenAddress(mint, owner);
-  const info = await connection.getAccountInfo(ata);
-  if (!info) {
-    const createIx = createAssociatedTokenAccountInstruction(
-      payer.publicKey,
-      ata,
-      owner,
-      mint,
-      TOKEN_PROGRAM_ID,
-      ASSOCIATED_TOKEN_PROGRAM_ID,
-    );
-    const tx = new Transaction().add(createIx);
-    await sendAndConfirmTransaction(connection, tx, [payer]);
-    console.log(`   → Created ATA ${ata.toBase58()}`);
-  }
-  return ata;
-}
-
 async function main() {
   if (!fs.existsSync(TOKENS_PATH)) {
     throw new Error('Token configuration not found. Run devnet-create-mints.ts first.');
   }
 
   const keypairPath = process.env.KEYPAIR ?? DEFAULT_KEYPAIR_PATH;
-  const secret = JSON.parse(fs.readFileSync(keypairPath, 'utf8')) as number[];
-  const payer = Keypair.fromSecretKey(new Uint8Array(secret));
+  const payer = loadOrGenerateKeypair(keypairPath);
 
-  const connection = new Connection(DEVNET_RPC, 'confirmed');
+  const connection = createHttpConnection(DEVNET_RPC, 'confirmed');
   console.log('🌐 RPC Endpoint:', DEVNET_RPC);
   console.log('🔑 Payer:', payer.publicKey.toBase58());
 
   const tokens = JSON.parse(fs.readFileSync(TOKENS_PATH, 'utf8')) as TokenConfigFile;
   const mintA = new PublicKey(tokens.tokenA.mint);
   const mintB = new PublicKey(tokens.tokenB.mint);
+
+  const feeOwner = process.env.FEE_OWNER ? new PublicKey(process.env.FEE_OWNER) : payer.publicKey;
 
   const [ammConfig] = deriveAmmConfigPda(AMM_CONFIG_INDEX);
   console.log('⚙️  AMM Config PDA:', ammConfig.toBase58());
@@ -124,7 +113,7 @@ async function main() {
     console.log('🛠️  Creating AMM config...');
     const configIx = createAmmConfigInstruction(payer.publicKey, ammConfig);
     const configTx = new Transaction().add(configIx);
-    const sig = await sendAndConfirmTransaction(connection, configTx, [payer]);
+    const sig = await sendTransactionWithRetry(connection, configTx, [payer]);
     console.log('   → Config transaction:', sig);
   } else {
     console.log('✅ AMM config already exists');
@@ -141,35 +130,32 @@ async function main() {
   console.log('   Observation:', cpSwapPdas.observationState.toBase58());
   console.log('   Continuum authority:', poolAuthority.toBase58(), `(bump ${poolAuthorityBump})`);
 
+  const token0MintInfo = await connection.getAccountInfo(cpSwapPdas.sortedToken0);
+  const token1MintInfo = await connection.getAccountInfo(cpSwapPdas.sortedToken1);
+  console.log('   Token0 mint owner :', token0MintInfo?.owner.toBase58());
+  console.log('   Token1 mint owner :', token1MintInfo?.owner.toBase58());
+
   const creatorToken0 = await ensureAta(connection, payer, payer.publicKey, cpSwapPdas.sortedToken0);
   const creatorToken1 = await ensureAta(connection, payer, payer.publicKey, cpSwapPdas.sortedToken1);
-  const creatorLp = await ensureAta(connection, payer, payer.publicKey, cpSwapPdas.lpMint);
+  const creatorLp = await getAssociatedTokenAddress(cpSwapPdas.lpMint, payer.publicKey);
   console.log('   Creator token0 ATA:', creatorToken0.toBase58());
   console.log('   Creator token1 ATA:', creatorToken1.toBase58());
   console.log('   Creator LP ATA   :', creatorLp.toBase58());
+  console.log('   Fee owner        :', feeOwner.toBase58());
 
-  const feeAccount = await getAssociatedTokenAddress(cpSwapPdas.sortedToken0, DEFAULT_FEE_OWNER);
-  const feeAccountInfo = await connection.getAccountInfo(feeAccount);
-  const preInstructions: Transaction[] = [];
-  if (!feeAccountInfo) {
-    const createFeeIx = createAssociatedTokenAccountInstruction(
-      payer.publicKey,
-      feeAccount,
-      DEFAULT_FEE_OWNER,
-      cpSwapPdas.sortedToken0,
-      TOKEN_PROGRAM_ID,
-      ASSOCIATED_TOKEN_PROGRAM_ID,
-    );
-    preInstructions.push(new Transaction().add(createFeeIx));
-    console.log('   → Fee account will be created for', DEFAULT_FEE_OWNER.toBase58());
-  }
+  const feeAtaAddress = await getAssociatedTokenAddress(cpSwapPdas.sortedToken0, feeOwner);
+  const feeAtaInfo = await connection.getAccountInfo(feeAtaAddress, 'confirmed');
+  console.log('   Fee ATA exists?   :', !!feeAtaInfo);
+  const feeAccount = feeAtaInfo
+    ? feeAtaAddress
+    : await ensureAta(connection, payer, feeOwner, cpSwapPdas.sortedToken0);
+  console.log('   Fee owner token0 ATA:', feeAccount.toBase58());
+  console.log('   Fee ATA address  :', feeAtaAddress.toBase58());
 
-  for (const tx of preInstructions) {
-    await sendAndConfirmTransaction(connection, tx, [payer]);
-  }
-
-  const initAmount0 = new BN(100_000 * 10 ** tokens.tokenA.decimals);
-  const initAmount1 = new BN(100_000 * 10 ** tokens.tokenB.decimals);
+  const decimals0 = findTokenDecimals(tokens, cpSwapPdas.sortedToken0);
+  const decimals1 = findTokenDecimals(tokens, cpSwapPdas.sortedToken1);
+  const initAmount0 = amountWithDecimals(100, decimals0);
+  const initAmount1 = amountWithDecimals(100, decimals1);
   const openTime = new BN(Math.floor(Date.now() / 1000));
 
   const initIx = createInitializeCpSwapPoolDirectInstruction({
@@ -180,11 +166,11 @@ async function main() {
     initAmount0,
     initAmount1,
     openTime,
-    feeOwner: DEFAULT_FEE_OWNER,
+    feeOwner,
   });
 
   const tx = new Transaction().add(initIx);
-  const signature = await sendAndConfirmTransaction(connection, tx, [payer]);
+  const signature = await sendTransactionWithRetry(connection, tx, [payer]);
   console.log('\n✅ Pool initialized! Signature:', signature);
 
   const payload = {

--- a/sdk/examples/devnet-init-pool.ts
+++ b/sdk/examples/devnet-init-pool.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env ts-node
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js';
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountInstruction,
+  getAssociatedTokenAddress,
+} from '@solana/spl-token';
+import BN from 'bn.js';
+import fs from 'fs';
+import path from 'path';
+
+import { CP_SWAP_PROGRAM_ID, CONTINUUM_PROGRAM_ID } from '../src/constants';
+import { getPoolAuthorityPDA } from '../src/utils/pda';
+import {
+  createInitializeCpSwapPoolDirectInstruction,
+  getCpSwapPDAs,
+} from '../src/instructions/initializeCpSwapPoolDirect';
+
+const DEVNET_RPC = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
+const DEFAULT_KEYPAIR_PATH = path.join(process.env.HOME ?? '.', '.config/solana/id.json');
+const TOKENS_PATH = path.join(__dirname, '../../config/devnet-tokens.json');
+const OUTPUT_PATH = path.join(__dirname, '../../config/devnet-pool.json');
+
+const DEFAULT_FEE_OWNER = new PublicKey('GsV1jugD8ftfWBYNykA9SLK2V4mQqUW2sLop8MAfjVRq');
+const AMM_CONFIG_INDEX = Number(process.env.AMM_CONFIG_INDEX ?? 42);
+const TRADE_FEE_BPS = Number(process.env.TRADE_FEE_BPS ?? 2500);
+const PROTOCOL_FEE_BPS = Number(process.env.PROTOCOL_FEE_BPS ?? 0);
+const FUND_FEE_BPS = Number(process.env.FUND_FEE_BPS ?? 0);
+const TICK_SPACING = Number(process.env.TICK_SPACING ?? 64);
+
+interface TokenConfigFile {
+  network: string;
+  owner: string;
+  tokenA: { mint: string; decimals: number; symbol: string; account: string };
+  tokenB: { mint: string; decimals: number; symbol: string; account: string };
+}
+
+function deriveAmmConfigPda(index: number): [PublicKey, number] {
+  const indexBuffer = Buffer.alloc(2);
+  indexBuffer.writeUInt16LE(index);
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from('amm_config'), indexBuffer],
+    CP_SWAP_PROGRAM_ID,
+  );
+}
+
+function createAmmConfigInstruction(owner: PublicKey, ammConfig: PublicKey): TransactionInstruction {
+  const data = Buffer.concat([
+    Buffer.from([72, 186, 156, 243, 103, 195, 75, 79]),
+    Buffer.from([AMM_CONFIG_INDEX & 0xff]),
+    new BN(TICK_SPACING).toArrayLike(Buffer, 'le', 2),
+    new BN(TRADE_FEE_BPS).toArrayLike(Buffer, 'le', 4),
+    new BN(PROTOCOL_FEE_BPS).toArrayLike(Buffer, 'le', 4),
+    new BN(FUND_FEE_BPS).toArrayLike(Buffer, 'le', 4),
+  ]);
+
+  return new TransactionInstruction({
+    programId: CP_SWAP_PROGRAM_ID,
+    keys: [
+      { pubkey: owner, isSigner: true, isWritable: true },
+      { pubkey: ammConfig, isSigner: false, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  });
+}
+
+async function ensureAta(
+  connection: Connection,
+  payer: Keypair,
+  owner: PublicKey,
+  mint: PublicKey,
+): Promise<PublicKey> {
+  const ata = await getAssociatedTokenAddress(mint, owner);
+  const info = await connection.getAccountInfo(ata);
+  if (!info) {
+    const createIx = createAssociatedTokenAccountInstruction(
+      payer.publicKey,
+      ata,
+      owner,
+      mint,
+      TOKEN_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+    );
+    const tx = new Transaction().add(createIx);
+    await sendAndConfirmTransaction(connection, tx, [payer]);
+    console.log(`   → Created ATA ${ata.toBase58()}`);
+  }
+  return ata;
+}
+
+async function main() {
+  if (!fs.existsSync(TOKENS_PATH)) {
+    throw new Error('Token configuration not found. Run devnet-create-mints.ts first.');
+  }
+
+  const keypairPath = process.env.KEYPAIR ?? DEFAULT_KEYPAIR_PATH;
+  const secret = JSON.parse(fs.readFileSync(keypairPath, 'utf8')) as number[];
+  const payer = Keypair.fromSecretKey(new Uint8Array(secret));
+
+  const connection = new Connection(DEVNET_RPC, 'confirmed');
+  console.log('🌐 RPC Endpoint:', DEVNET_RPC);
+  console.log('🔑 Payer:', payer.publicKey.toBase58());
+
+  const tokens = JSON.parse(fs.readFileSync(TOKENS_PATH, 'utf8')) as TokenConfigFile;
+  const mintA = new PublicKey(tokens.tokenA.mint);
+  const mintB = new PublicKey(tokens.tokenB.mint);
+
+  const [ammConfig] = deriveAmmConfigPda(AMM_CONFIG_INDEX);
+  console.log('⚙️  AMM Config PDA:', ammConfig.toBase58());
+
+  const existingConfig = await connection.getAccountInfo(ammConfig);
+  if (!existingConfig) {
+    console.log('🛠️  Creating AMM config...');
+    const configIx = createAmmConfigInstruction(payer.publicKey, ammConfig);
+    const configTx = new Transaction().add(configIx);
+    const sig = await sendAndConfirmTransaction(connection, configTx, [payer]);
+    console.log('   → Config transaction:', sig);
+  } else {
+    console.log('✅ AMM config already exists');
+  }
+
+  const cpSwapPdas = getCpSwapPDAs(mintA, mintB, ammConfig);
+  const [poolAuthority, poolAuthorityBump] = getPoolAuthorityPDA(cpSwapPdas.poolState);
+
+  console.log('\n🏊 Pool PDAs:');
+  console.log('   Pool state:', cpSwapPdas.poolState.toBase58());
+  console.log('   LP mint:', cpSwapPdas.lpMint.toBase58());
+  console.log('   Vault 0:', cpSwapPdas.vault0.toBase58());
+  console.log('   Vault 1:', cpSwapPdas.vault1.toBase58());
+  console.log('   Observation:', cpSwapPdas.observationState.toBase58());
+  console.log('   Continuum authority:', poolAuthority.toBase58(), `(bump ${poolAuthorityBump})`);
+
+  const creatorToken0 = await ensureAta(connection, payer, payer.publicKey, cpSwapPdas.sortedToken0);
+  const creatorToken1 = await ensureAta(connection, payer, payer.publicKey, cpSwapPdas.sortedToken1);
+  const creatorLp = await ensureAta(connection, payer, payer.publicKey, cpSwapPdas.lpMint);
+  console.log('   Creator token0 ATA:', creatorToken0.toBase58());
+  console.log('   Creator token1 ATA:', creatorToken1.toBase58());
+  console.log('   Creator LP ATA   :', creatorLp.toBase58());
+
+  const feeAccount = await getAssociatedTokenAddress(cpSwapPdas.sortedToken0, DEFAULT_FEE_OWNER);
+  const feeAccountInfo = await connection.getAccountInfo(feeAccount);
+  const preInstructions: Transaction[] = [];
+  if (!feeAccountInfo) {
+    const createFeeIx = createAssociatedTokenAccountInstruction(
+      payer.publicKey,
+      feeAccount,
+      DEFAULT_FEE_OWNER,
+      cpSwapPdas.sortedToken0,
+      TOKEN_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+    );
+    preInstructions.push(new Transaction().add(createFeeIx));
+    console.log('   → Fee account will be created for', DEFAULT_FEE_OWNER.toBase58());
+  }
+
+  for (const tx of preInstructions) {
+    await sendAndConfirmTransaction(connection, tx, [payer]);
+  }
+
+  const initAmount0 = new BN(100_000 * 10 ** tokens.tokenA.decimals);
+  const initAmount1 = new BN(100_000 * 10 ** tokens.tokenB.decimals);
+  const openTime = new BN(Math.floor(Date.now() / 1000));
+
+  const initIx = createInitializeCpSwapPoolDirectInstruction({
+    creator: payer.publicKey,
+    ammConfig,
+    token0Mint: mintA,
+    token1Mint: mintB,
+    initAmount0,
+    initAmount1,
+    openTime,
+    feeOwner: DEFAULT_FEE_OWNER,
+  });
+
+  const tx = new Transaction().add(initIx);
+  const signature = await sendAndConfirmTransaction(connection, tx, [payer]);
+  console.log('\n✅ Pool initialized! Signature:', signature);
+
+  const payload = {
+    network: 'devnet',
+    createdAt: new Date().toISOString(),
+    creator: payer.publicKey.toBase58(),
+    poolId: cpSwapPdas.poolState.toBase58(),
+    ammConfig: ammConfig.toBase58(),
+    token0Mint: cpSwapPdas.sortedToken0.toBase58(),
+    token1Mint: cpSwapPdas.sortedToken1.toBase58(),
+    token0Vault: cpSwapPdas.vault0.toBase58(),
+    token1Vault: cpSwapPdas.vault1.toBase58(),
+    lpMint: cpSwapPdas.lpMint.toBase58(),
+    observationState: cpSwapPdas.observationState.toBase58(),
+    continuumAuthority: poolAuthority.toBase58(),
+    continuumAuthorityBump: poolAuthorityBump,
+    cpSwapAuthority: cpSwapPdas.cpSwapAuthority.toBase58(),
+    initAmount0: initAmount0.toString(),
+    initAmount1: initAmount1.toString(),
+    cpSwapProgram: CP_SWAP_PROGRAM_ID.toBase58(),
+    continuumProgram: CONTINUUM_PROGRAM_ID.toBase58(),
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(payload, null, 2));
+  console.log(`📝 Saved pool configuration to ${OUTPUT_PATH}`);
+}
+
+main().catch(err => {
+  console.error('❌ Failed to initialize pool:', err);
+  process.exit(1);
+});

--- a/sdk/examples/devnet-lp-operations.ts
+++ b/sdk/examples/devnet-lp-operations.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env ts-node
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js';
+import {
+  TOKEN_PROGRAM_ID,
+  getAccount,
+  getAssociatedTokenAddress,
+} from '@solana/spl-token';
+import BN from 'bn.js';
+import fs from 'fs';
+import path from 'path';
+
+import { CP_SWAP_PROGRAM_ID } from '../src/constants';
+import { getPoolAuthorityPDA } from '../src/utils/pda';
+import {
+  createDepositLpInstruction,
+  createWithdrawLpInstruction,
+} from '../src/instructions';
+
+const DEVNET_RPC = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
+const DEFAULT_KEYPAIR_PATH = path.join(process.env.HOME ?? '.', '.config/solana/id.json');
+const TOKENS_PATH = path.join(__dirname, '../../config/devnet-tokens.json');
+const POOL_PATH = path.join(__dirname, '../../config/devnet-pool.json');
+
+interface TokenInfo {
+  mint: string;
+  decimals: number;
+  symbol: string;
+  account: string;
+}
+
+interface TokenConfigFile {
+  tokenA: TokenInfo;
+  tokenB: TokenInfo;
+}
+
+interface PoolConfigFile {
+  poolId: string;
+  ammConfig: string;
+  token0Mint: string;
+  token1Mint: string;
+  token0Vault: string;
+  token1Vault: string;
+  lpMint: string;
+  continuumAuthority: string;
+}
+
+function findDecimals(tokens: TokenConfigFile, mint: string): number {
+  if (tokens.tokenA.mint === mint) return tokens.tokenA.decimals;
+  if (tokens.tokenB.mint === mint) return tokens.tokenB.decimals;
+  throw new Error(`Unable to determine decimals for mint ${mint}`);
+}
+
+async function ensureAta(connection: Connection, owner: PublicKey, mint: PublicKey): Promise<PublicKey> {
+  return getAssociatedTokenAddress(mint, owner);
+}
+
+async function main() {
+  if (!fs.existsSync(TOKENS_PATH) || !fs.existsSync(POOL_PATH)) {
+    throw new Error('Missing configuration. Run devnet-create-mints.ts and devnet-init-pool.ts first.');
+  }
+
+  const keypairPath = process.env.KEYPAIR ?? DEFAULT_KEYPAIR_PATH;
+  const payer = Keypair.fromSecretKey(new Uint8Array(JSON.parse(fs.readFileSync(keypairPath, 'utf8'))));
+
+  const connection = new Connection(DEVNET_RPC, 'confirmed');
+  console.log('🌐 RPC Endpoint:', DEVNET_RPC);
+  console.log('👤 User:', payer.publicKey.toBase58());
+
+  const tokens = JSON.parse(fs.readFileSync(TOKENS_PATH, 'utf8')) as TokenConfigFile;
+  const pool = JSON.parse(fs.readFileSync(POOL_PATH, 'utf8')) as PoolConfigFile;
+
+  const poolId = new PublicKey(pool.poolId);
+  const token0Mint = new PublicKey(pool.token0Mint);
+  const token1Mint = new PublicKey(pool.token1Mint);
+  const token0Vault = new PublicKey(pool.token0Vault);
+  const token1Vault = new PublicKey(pool.token1Vault);
+  const lpMint = new PublicKey(pool.lpMint);
+
+  const decimals0 = findDecimals(tokens, pool.token0Mint);
+  const decimals1 = findDecimals(tokens, pool.token1Mint);
+
+  const userToken0 = await ensureAta(connection, payer.publicKey, token0Mint);
+  const userToken1 = await ensureAta(connection, payer.publicKey, token1Mint);
+  const userLp = await ensureAta(connection, payer.publicKey, lpMint);
+
+  const [poolAuthority, poolAuthorityBump] = getPoolAuthorityPDA(poolId);
+  console.log('🏛️  Continuum pool authority:', poolAuthority.toBase58(), `(bump ${poolAuthorityBump})`);
+
+  const depositAmount0 = new BN(10_000 * 10 ** decimals0);
+  const depositAmount1 = new BN(10_000 * 10 ** decimals1);
+
+  const remainingAccounts = [
+    { pubkey: payer.publicKey, isSigner: true, isWritable: false },
+    { pubkey: poolId, isSigner: false, isWritable: true },
+    { pubkey: poolAuthority, isSigner: false, isWritable: false },
+    { pubkey: userLp, isSigner: false, isWritable: true },
+    { pubkey: userToken0, isSigner: false, isWritable: true },
+    { pubkey: userToken1, isSigner: false, isWritable: true },
+    { pubkey: token0Vault, isSigner: false, isWritable: true },
+    { pubkey: token1Vault, isSigner: false, isWritable: true },
+    { pubkey: lpMint, isSigner: false, isWritable: true },
+    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: token0Mint, isSigner: false, isWritable: false },
+    { pubkey: token1Mint, isSigner: false, isWritable: false },
+  ];
+
+  console.log('\n📥 Depositing liquidity via CTM wrapper...');
+  const depositIx = createDepositLpInstruction({
+    user: payer.publicKey,
+    cpSwapProgram: CP_SWAP_PROGRAM_ID,
+    poolId,
+    minLpAmount: new BN(0),
+    maxAmount0: depositAmount0,
+    maxAmount1: depositAmount1,
+    poolAuthorityBump,
+    remainingAccounts,
+  });
+
+  const depositTx = new Transaction().add(depositIx);
+  const depositSig = await sendAndConfirmTransaction(connection, depositTx, [payer]);
+  console.log('   → Deposit transaction:', depositSig);
+
+  const postDepositToken0 = await getAccount(connection, userToken0);
+  const postDepositToken1 = await getAccount(connection, userToken1);
+  const postDepositLp = await getAccount(connection, userLp);
+  console.log('   User token0 balance:', Number(postDepositToken0.amount) / 10 ** decimals0);
+  console.log('   User token1 balance:', Number(postDepositToken1.amount) / 10 ** decimals1);
+  console.log('   User LP balance:', postDepositLp.amount.toString());
+
+  const lpAmount = new BN(postDepositLp.amount.toString());
+  const withdrawAmount = lpAmount.divn(2);
+  if (withdrawAmount.isZero()) {
+    console.log('\n⚠️  No LP tokens minted, skipping withdraw.');
+    return;
+  }
+
+  console.log('\n📤 Withdrawing liquidity via CTM wrapper...');
+  const withdrawIx = createWithdrawLpInstruction({
+    user: payer.publicKey,
+    cpSwapProgram: CP_SWAP_PROGRAM_ID,
+    poolId,
+    lpAmount: withdrawAmount,
+    minAmount0: new BN(0),
+    minAmount1: new BN(0),
+    poolAuthorityBump,
+    remainingAccounts,
+  });
+
+  const withdrawTx = new Transaction().add(withdrawIx);
+  const withdrawSig = await sendAndConfirmTransaction(connection, withdrawTx, [payer]);
+  console.log('   → Withdraw transaction:', withdrawSig);
+
+  const finalToken0 = await getAccount(connection, userToken0);
+  const finalToken1 = await getAccount(connection, userToken1);
+  const finalLp = await getAccount(connection, userLp);
+  console.log('\n📊 Final balances:');
+  console.log('   Token0:', Number(finalToken0.amount) / 10 ** decimals0);
+  console.log('   Token1:', Number(finalToken1.amount) / 10 ** decimals1);
+  console.log('   LP    :', finalLp.amount.toString());
+}
+
+main().catch(err => {
+  console.error('❌ LP operations failed:', err);
+  process.exit(1);
+});

--- a/sdk/examples/devnet-lp-operations.ts
+++ b/sdk/examples/devnet-lp-operations.ts
@@ -1,17 +1,7 @@
 #!/usr/bin/env ts-node
 
-import {
-  Connection,
-  Keypair,
-  PublicKey,
-  Transaction,
-  sendAndConfirmTransaction,
-} from '@solana/web3.js';
-import {
-  TOKEN_PROGRAM_ID,
-  getAccount,
-  getAssociatedTokenAddress,
-} from '@solana/spl-token';
+import { Keypair, PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js';
+import { TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID, createTransferInstruction, getAccount, getMint } from '@solana/spl-token';
 import BN from 'bn.js';
 import fs from 'fs';
 import path from 'path';
@@ -22,6 +12,12 @@ import {
   createDepositLpInstruction,
   createWithdrawLpInstruction,
 } from '../src/instructions';
+import {
+  createHttpConnection,
+  ensureAta,
+  loadOrGenerateKeypair,
+  sendTransactionWithRetry,
+} from './utils';
 
 const DEVNET_RPC = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
 const DEFAULT_KEYPAIR_PATH = path.join(process.env.HOME ?? '.', '.config/solana/id.json');
@@ -49,6 +45,7 @@ interface PoolConfigFile {
   token1Vault: string;
   lpMint: string;
   continuumAuthority: string;
+  cpSwapAuthority: string;
 }
 
 function findDecimals(tokens: TokenConfigFile, mint: string): number {
@@ -57,8 +54,8 @@ function findDecimals(tokens: TokenConfigFile, mint: string): number {
   throw new Error(`Unable to determine decimals for mint ${mint}`);
 }
 
-async function ensureAta(connection: Connection, owner: PublicKey, mint: PublicKey): Promise<PublicKey> {
-  return getAssociatedTokenAddress(mint, owner);
+function amountWithDecimals(amount: number, decimals: number): BN {
+  return new BN(amount).mul(new BN(10).pow(new BN(decimals)));
 }
 
 async function main() {
@@ -67,9 +64,9 @@ async function main() {
   }
 
   const keypairPath = process.env.KEYPAIR ?? DEFAULT_KEYPAIR_PATH;
-  const payer = Keypair.fromSecretKey(new Uint8Array(JSON.parse(fs.readFileSync(keypairPath, 'utf8'))));
+  const payer = loadOrGenerateKeypair(keypairPath);
 
-  const connection = new Connection(DEVNET_RPC, 'confirmed');
+  const connection = createHttpConnection(DEVNET_RPC, 'confirmed');
   console.log('🌐 RPC Endpoint:', DEVNET_RPC);
   console.log('👤 User:', payer.publicKey.toBase58());
 
@@ -77,39 +74,141 @@ async function main() {
   const pool = JSON.parse(fs.readFileSync(POOL_PATH, 'utf8')) as PoolConfigFile;
 
   const poolId = new PublicKey(pool.poolId);
+  const cpSwapAuthority = new PublicKey(pool.cpSwapAuthority);
   const token0Mint = new PublicKey(pool.token0Mint);
   const token1Mint = new PublicKey(pool.token1Mint);
   const token0Vault = new PublicKey(pool.token0Vault);
   const token1Vault = new PublicKey(pool.token1Vault);
   const lpMint = new PublicKey(pool.lpMint);
+  const memoProgram = new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr');
 
   const decimals0 = findDecimals(tokens, pool.token0Mint);
   const decimals1 = findDecimals(tokens, pool.token1Mint);
 
-  const userToken0 = await ensureAta(connection, payer.publicKey, token0Mint);
-  const userToken1 = await ensureAta(connection, payer.publicKey, token1Mint);
-  const userLp = await ensureAta(connection, payer.publicKey, lpMint);
+  const continuumAuthority = new PublicKey(pool.continuumAuthority);
+
+  const userToken0 = await ensureAta(connection, payer, payer.publicKey, token0Mint);
+  const userToken1 = await ensureAta(connection, payer, payer.publicKey, token1Mint);
+  const continuumToken0 = await ensureAta(connection, payer, continuumAuthority, token0Mint);
+  const continuumToken1 = await ensureAta(connection, payer, continuumAuthority, token1Mint);
+  const continuumLp = await ensureAta(connection, payer, continuumAuthority, lpMint);
 
   const [poolAuthority, poolAuthorityBump] = getPoolAuthorityPDA(poolId);
+  if (!poolAuthority.equals(continuumAuthority)) {
+    console.warn('⚠️  Derived pool authority does not match stored continuum authority!');
+  }
   console.log('🏛️  Continuum pool authority:', poolAuthority.toBase58(), `(bump ${poolAuthorityBump})`);
+  console.log('   Continuum token0 ATA:', continuumToken0.toBase58());
+  console.log('   Continuum token1 ATA:', continuumToken1.toBase58());
+  console.log('   Continuum LP ATA   :', continuumLp.toBase58());
 
-  const depositAmount0 = new BN(10_000 * 10 ** decimals0);
-  const depositAmount1 = new BN(10_000 * 10 ** decimals1);
+  const depositAmount0 = amountWithDecimals(10, decimals0);
+  const depositAmount1 = amountWithDecimals(10, decimals1);
+  const depositAmount0Big = BigInt(depositAmount0.toString());
+  const depositAmount1Big = BigInt(depositAmount1.toString());
+
+  const vault0Info = await getAccount(connection, token0Vault);
+  const vault1Info = await getAccount(connection, token1Vault);
+  const lpMintInfo = await getMint(connection, lpMint);
+  const totalToken0 = BigInt(vault0Info.amount.toString());
+  const totalToken1 = BigInt(vault1Info.amount.toString());
+  const lpSupply = BigInt(lpMintInfo.supply.toString());
+  if (totalToken0 === 0n || totalToken1 === 0n || lpSupply === 0n) {
+    throw new Error('Pool has zero liquidity; cannot compute proportional deposit.');
+  }
+
+  const ceilDiv = (num: bigint, denom: bigint) => (num + denom - 1n) / denom;
+
+  let lpAmountBig = depositAmount0Big * lpSupply / totalToken0;
+  const lpFromToken1 = depositAmount1Big * lpSupply / totalToken1;
+  if (lpFromToken1 < lpAmountBig) {
+    lpAmountBig = lpFromToken1;
+  }
+
+  if (lpAmountBig === 0n) {
+    throw new Error('Deposit amounts too small to mint any LP tokens. Increase the deposit.');
+  }
+
+  let requiredToken0 = ceilDiv(lpAmountBig * totalToken0, lpSupply);
+  let requiredToken1 = ceilDiv(lpAmountBig * totalToken1, lpSupply);
+
+  while ((requiredToken0 > depositAmount0Big || requiredToken1 > depositAmount1Big) && lpAmountBig > 0n) {
+    lpAmountBig -= 1n;
+    requiredToken0 = ceilDiv(lpAmountBig * totalToken0, lpSupply);
+    requiredToken1 = ceilDiv(lpAmountBig * totalToken1, lpSupply);
+  }
+
+  if (lpAmountBig === 0n) {
+    throw new Error('Unable to derive LP amount within provided token budgets.');
+  }
+
+  console.log('   Target LP to mint   :', lpAmountBig.toString());
+  console.log('   Required token0 amt :', requiredToken0.toString());
+  console.log('   Required token1 amt :', requiredToken1.toString());
+
+  const lpTokenAmount = new BN(lpAmountBig.toString());
+  const maxToken0Amount = new BN(depositAmount0Big.toString());
+  const maxToken1Amount = new BN(depositAmount1Big.toString());
+
+  const userToken0Account = await getAccount(connection, userToken0);
+  const userToken1Account = await getAccount(connection, userToken1);
+  if (userToken0Account.amount < depositAmount0Big) {
+    throw new Error('Insufficient balance in user token0 account');
+  }
+  if (userToken1Account.amount < depositAmount1Big) {
+    throw new Error('Insufficient balance in user token1 account');
+  }
+
+  console.log('\n🔄 Prefunding Continuum authority token accounts...');
+  const transferIxs = [] as TransactionInstruction[];
+  if (depositAmount0Big > 0n) {
+    transferIxs.push(
+      createTransferInstruction(
+        userToken0,
+        continuumToken0,
+        payer.publicKey,
+        depositAmount0Big,
+        [],
+        TOKEN_PROGRAM_ID,
+      ),
+    );
+  }
+  if (depositAmount1Big > 0n) {
+    transferIxs.push(
+      createTransferInstruction(
+        userToken1,
+        continuumToken1,
+        payer.publicKey,
+        depositAmount1Big,
+        [],
+        TOKEN_PROGRAM_ID,
+      ),
+    );
+  }
+
+  if (transferIxs.length) {
+    const transferTx = new Transaction().add(...transferIxs);
+    const transferSig = await sendTransactionWithRetry(connection, transferTx, [payer]);
+    console.log('   → Transfer signature:', transferSig);
+  } else {
+    console.log('   → No transfers required (zero deposit amounts)');
+  }
 
   const remainingAccounts = [
-    { pubkey: payer.publicKey, isSigner: true, isWritable: false },
+    { pubkey: continuumAuthority, isSigner: false, isWritable: false },
+    { pubkey: cpSwapAuthority, isSigner: false, isWritable: false },
     { pubkey: poolId, isSigner: false, isWritable: true },
-    { pubkey: poolAuthority, isSigner: false, isWritable: false },
-    { pubkey: userLp, isSigner: false, isWritable: true },
-    { pubkey: userToken0, isSigner: false, isWritable: true },
-    { pubkey: userToken1, isSigner: false, isWritable: true },
+    { pubkey: continuumLp, isSigner: false, isWritable: true },
+    { pubkey: continuumToken0, isSigner: false, isWritable: true },
+    { pubkey: continuumToken1, isSigner: false, isWritable: true },
     { pubkey: token0Vault, isSigner: false, isWritable: true },
     { pubkey: token1Vault, isSigner: false, isWritable: true },
-    { pubkey: lpMint, isSigner: false, isWritable: true },
     { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
-    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: TOKEN_2022_PROGRAM_ID, isSigner: false, isWritable: false },
     { pubkey: token0Mint, isSigner: false, isWritable: false },
     { pubkey: token1Mint, isSigner: false, isWritable: false },
+    { pubkey: lpMint, isSigner: false, isWritable: true },
+    { pubkey: memoProgram, isSigner: false, isWritable: false },
   ];
 
   console.log('\n📥 Depositing liquidity via CTM wrapper...');
@@ -117,30 +216,31 @@ async function main() {
     user: payer.publicKey,
     cpSwapProgram: CP_SWAP_PROGRAM_ID,
     poolId,
-    minLpAmount: new BN(0),
-    maxAmount0: depositAmount0,
-    maxAmount1: depositAmount1,
+    minLpAmount: lpTokenAmount,
+    maxAmount0: maxToken0Amount,
+    maxAmount1: maxToken1Amount,
     poolAuthorityBump,
     remainingAccounts,
   });
 
   const depositTx = new Transaction().add(depositIx);
-  const depositSig = await sendAndConfirmTransaction(connection, depositTx, [payer]);
+  const depositSig = await sendTransactionWithRetry(connection, depositTx, [payer]);
   console.log('   → Deposit transaction:', depositSig);
 
-  const postDepositToken0 = await getAccount(connection, userToken0);
-  const postDepositToken1 = await getAccount(connection, userToken1);
-  const postDepositLp = await getAccount(connection, userLp);
-  console.log('   User token0 balance:', Number(postDepositToken0.amount) / 10 ** decimals0);
-  console.log('   User token1 balance:', Number(postDepositToken1.amount) / 10 ** decimals1);
-  console.log('   User LP balance:', postDepositLp.amount.toString());
+  const postDepositToken0 = await getAccount(connection, continuumToken0);
+  const postDepositToken1 = await getAccount(connection, continuumToken1);
+  const postDepositLp = await getAccount(connection, continuumLp);
+  console.log('   Continuum token0 balance:', Number(postDepositToken0.amount) / 10 ** decimals0);
+  console.log('   Continuum token1 balance:', Number(postDepositToken1.amount) / 10 ** decimals1);
+  console.log('   Continuum LP balance   :', postDepositLp.amount.toString());
 
-  const lpAmount = new BN(postDepositLp.amount.toString());
-  const withdrawAmount = lpAmount.divn(2);
-  if (withdrawAmount.isZero()) {
+  const postDepositLpAmount = BigInt(postDepositLp.amount.toString());
+  if (postDepositLpAmount === 0n) {
     console.log('\n⚠️  No LP tokens minted, skipping withdraw.');
     return;
   }
+
+  const withdrawAmount = new BN(postDepositLpAmount.toString());
 
   console.log('\n📤 Withdrawing liquidity via CTM wrapper...');
   const withdrawIx = createWithdrawLpInstruction({
@@ -155,16 +255,22 @@ async function main() {
   });
 
   const withdrawTx = new Transaction().add(withdrawIx);
-  const withdrawSig = await sendAndConfirmTransaction(connection, withdrawTx, [payer]);
+  const withdrawSig = await sendTransactionWithRetry(connection, withdrawTx, [payer]);
   console.log('   → Withdraw transaction:', withdrawSig);
 
-  const finalToken0 = await getAccount(connection, userToken0);
-  const finalToken1 = await getAccount(connection, userToken1);
-  const finalLp = await getAccount(connection, userLp);
-  console.log('\n📊 Final balances:');
-  console.log('   Token0:', Number(finalToken0.amount) / 10 ** decimals0);
-  console.log('   Token1:', Number(finalToken1.amount) / 10 ** decimals1);
-  console.log('   LP    :', finalLp.amount.toString());
+  const finalContinuumToken0 = await getAccount(connection, continuumToken0);
+  const finalContinuumToken1 = await getAccount(connection, continuumToken1);
+  const finalContinuumLp = await getAccount(connection, continuumLp);
+  console.log('\n📊 Final Continuum balances:');
+  console.log('   Token0:', Number(finalContinuumToken0.amount) / 10 ** decimals0);
+  console.log('   Token1:', Number(finalContinuumToken1.amount) / 10 ** decimals1);
+  console.log('   LP    :', finalContinuumLp.amount.toString());
+
+  const finalUserToken0 = await getAccount(connection, userToken0);
+  const finalUserToken1 = await getAccount(connection, userToken1);
+  console.log('\n👤 User balances (post-withdraw):');
+  console.log('   Token0:', Number(finalUserToken0.amount) / 10 ** decimals0);
+  console.log('   Token1:', Number(finalUserToken1.amount) / 10 ** decimals1);
 }
 
 main().catch(err => {

--- a/sdk/examples/utils.ts
+++ b/sdk/examples/utils.ts
@@ -1,0 +1,180 @@
+import {
+  Commitment,
+  Connection,
+  ConnectionConfig,
+  Keypair,
+  PublicKey,
+  Signer,
+  Transaction,
+} from '@solana/web3.js';
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddress,
+} from '@solana/spl-token';
+import fs from 'fs';
+import path from 'path';
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+
+export const proxyUrl = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
+const undiciProxyAgent = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
+
+if (undiciProxyAgent) {
+  setGlobalDispatcher(undiciProxyAgent);
+}
+
+const commitmentRank: Record<'processed' | 'confirmed' | 'finalized', number> = {
+  processed: 0,
+  confirmed: 1,
+  finalized: 2,
+};
+
+const commitmentAliases: Record<string, 'processed' | 'confirmed' | 'finalized'> = {
+  processed: 'processed',
+  recent: 'processed',
+  single: 'processed',
+  confirmed: 'confirmed',
+  singleGossip: 'confirmed',
+  finalized: 'finalized',
+  max: 'finalized',
+  root: 'finalized',
+};
+
+function normalizeCommitment(commitment: Commitment = 'confirmed'): 'processed' | 'confirmed' | 'finalized' {
+  return commitmentAliases[commitment] ?? 'confirmed';
+}
+
+export function createHttpConnection(endpoint: string, commitment: Commitment = 'confirmed'): Connection {
+  const config: ConnectionConfig = { commitment };
+  if (proxyUrl) {
+    config.httpAgent = false;
+    config.fetch = (input: any, init?: any) => (globalThis as any).fetch(input, init);
+  }
+  return new Connection(endpoint, config);
+}
+
+export function loadOrGenerateKeypair(keypairPath: string): Keypair {
+  const resolved = path.resolve(keypairPath);
+  if (fs.existsSync(resolved)) {
+    const secret = JSON.parse(fs.readFileSync(resolved, 'utf8')) as number[];
+    return Keypair.fromSecretKey(Uint8Array.from(secret));
+  }
+
+  const keypair = Keypair.generate();
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, JSON.stringify(Array.from(keypair.secretKey)));
+  console.log(`🆕 Generated new keypair at ${resolved}`);
+  return keypair;
+}
+
+export const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export async function confirmSignature(
+  connection: Connection,
+  signature: string,
+  commitment: Commitment = 'confirmed',
+  lastValidBlockHeight?: number,
+  timeoutMs = 60_000,
+): Promise<void> {
+  const desiredLevel = normalizeCommitment(commitment);
+  const start = Date.now();
+
+  while (true) {
+    const statusResp = await connection.getSignatureStatuses([signature]);
+    const status = statusResp.value[0];
+
+    if (status) {
+      if (status.err) {
+        throw new Error(`Transaction ${signature} failed: ${JSON.stringify(status.err)}`);
+      }
+
+      const currentLevel = status.confirmationStatus
+        ? normalizeCommitment(status.confirmationStatus)
+        : status.confirmations === null
+          ? 'finalized'
+          : status.confirmations !== undefined
+            ? status.confirmations > 0
+              ? 'confirmed'
+              : 'processed'
+            : undefined;
+
+      if (currentLevel && commitmentRank[currentLevel] >= commitmentRank[desiredLevel]) {
+        return;
+      }
+    }
+
+    if (lastValidBlockHeight !== undefined) {
+      const blockHeight = await connection.getBlockHeight(commitment);
+      if (blockHeight > lastValidBlockHeight) {
+        throw new Error(`Transaction ${signature} expired: block height ${blockHeight} > ${lastValidBlockHeight}`);
+      }
+    }
+
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for confirmation of ${signature}`);
+    }
+
+    await sleep(2_000);
+  }
+}
+
+export async function sendTransactionWithRetry(
+  connection: Connection,
+  transaction: Transaction,
+  signers: Signer[],
+  commitment: Commitment = 'confirmed',
+): Promise<string> {
+  if (!signers.length) {
+    throw new Error('At least one signer is required to send a transaction.');
+  }
+
+  const latestBlockhash = await connection.getLatestBlockhash(commitment);
+  transaction.recentBlockhash = latestBlockhash.blockhash;
+  if (!transaction.feePayer) {
+    transaction.feePayer = signers[0].publicKey;
+  }
+
+  const uniqueSigners = new Map<string, Signer>();
+  for (const signer of signers) {
+    uniqueSigners.set(signer.publicKey.toBase58(), signer);
+  }
+  transaction.sign(...uniqueSigners.values());
+
+  const raw = transaction.serialize();
+  const signature = await connection.sendRawTransaction(raw);
+  await confirmSignature(
+    connection,
+    signature,
+    commitment,
+    latestBlockhash.lastValidBlockHeight,
+  );
+  return signature;
+}
+
+export async function ensureAta(
+  connection: Connection,
+  payer: Keypair,
+  owner: PublicKey,
+  mint: PublicKey,
+): Promise<PublicKey> {
+  const ata = await getAssociatedTokenAddress(mint, owner, true);
+  const info = await connection.getAccountInfo(ata, 'confirmed');
+  if (!info) {
+    console.log(
+      `   → Creating ATA for ${owner.toBase58()} and mint ${mint.toBase58()}`,
+    );
+    const ix = createAssociatedTokenAccountIdempotentInstruction(
+      payer.publicKey,
+      ata,
+      owner,
+      mint,
+      TOKEN_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+    );
+    const tx = new Transaction().add(ix);
+    const sig = await sendTransactionWithRetry(connection, tx, [payer]);
+    console.log(`   → Created ATA ${ata.toBase58()} (${sig})`);
+  }
+  return ata;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "types": ["mocha", "chai", "node"],
-    "typeRoots": ["./node_modules/@types"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "lib": ["es2015"],
     "module": "commonjs",
     "target": "es6",

--- a/types/tweetnacl.d.ts
+++ b/types/tweetnacl.d.ts
@@ -1,0 +1,1 @@
+declare module 'tweetnacl';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,6 +1247,11 @@ tslib@^2.8.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+
 type-detect@^4.0.0, type-detect@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz"
@@ -1261,6 +1266,11 @@ undici-types@~7.12.0:
   version "7.12.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz"
   integrity sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==
+
+undici@^6.19.8:
+  version "6.21.3"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz"
+  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
 utf-8-validate@^5.0.2, utf-8-validate@>=5.0.2:
   version "5.0.10"


### PR DESCRIPTION
## Summary
- add devnet helper scripts to mint test tokens, initialize a CTM-controlled Raydium pool, and exercise LP deposit/withdraw flows via the SDK
- document the new scripts and usage instructions in the SDK README

## Testing
- npm --prefix sdk run build

------
https://chatgpt.com/codex/tasks/task_e_68ce69f8dc888331a0b9b084ce230443